### PR TITLE
Issue #984: Fix getWarehouse reflection call to match new 4-arg signature

### DIFF
--- a/src/com/etendoerp/metadata/auth/Utils.java
+++ b/src/com/etendoerp/metadata/auth/Utils.java
@@ -113,13 +113,13 @@ public class Utils {
    * @param defaultWarehouse  The default warehouse.
    * @return The selected warehouse.
    */
-  private static Warehouse getWarehouse(Warehouse warehouse, Organization selectedOrg, Warehouse defaultWarehouse) {
+  private static Warehouse getWarehouse(Warehouse warehouse, Organization selectedOrg, Warehouse defaultWarehouse, Role defaultRole) {
     try {
       Method method = SecureWebServicesUtils.class.getDeclaredMethod("getWarehouse", Warehouse.class,
-          Organization.class, Warehouse.class);
+          Organization.class, Warehouse.class, Role.class);
       method.setAccessible(true);
 
-      return (Warehouse) method.invoke(null, warehouse, selectedOrg, defaultWarehouse);
+      return (Warehouse) method.invoke(null, warehouse, selectedOrg, defaultWarehouse, defaultRole);
     } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
       throw new OBException(e);
     }
@@ -210,7 +210,7 @@ public class Utils {
 
       Role selectedRole = getRole(role, userRoleList, defaultWsRole, defaultRole);
       Organization selectedOrg = getOrganization(org, selectedRole, defaultRole, defaultOrg);
-      Warehouse selectedWarehouse = getWarehouse(warehouse, selectedOrg, warehouseFallback);
+      Warehouse selectedWarehouse = getWarehouse(warehouse, selectedOrg, warehouseFallback, defaultRole);
 
       if (SecureWebServicesUtils.isNewVersionPrivKey(privateKey)) {
         String algorithmUsed = getAlgorithmUsed();


### PR DESCRIPTION
## Summary

- `SecureWebServicesUtils.getWarehouse()` signature changed from 3 to 4 parameters (added `Role`) in [etendo_core#986](https://github.com/etendosoftware/etendo_core/pull/986).
- `Utils.java` in this module uses reflection to call that private method — updated the `getDeclaredMethod` lookup and `invoke` call to match the new 4-arg signature.

## Related

- etendo_core PR: https://github.com/etendosoftware/etendo_core/pull/986
- Jira: ETP-3676

## Test plan

- [ ] Existing tests in `UtilsTest` pass without changes
- [ ] `generateToken` flow resolves the correct warehouse via the updated reflection call