### PR TITLE
Feature ETP-4378: Eliminate N+1 in MenuBuilder (Process/ModelImplementation)

### DIFF
--- a/src-test/src/com/etendoerp/metadata/builders/MenuBuilderTest.java
+++ b/src-test/src/com/etendoerp/metadata/builders/MenuBuilderTest.java
@@ -53,6 +53,8 @@ import org.hibernate.query.Query;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.Mock;
 import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
@@ -119,6 +121,9 @@ class MenuBuilderTest {
   private static final String VIEW_MENU = "View Menu";
   private static final String VIEW_DESC = "View Desc";
   private static final String VIEW_ID = "viewId";
+  private static final String VIEW_MENU_ID = "VIEW_MENU_ID";
+  private static final String FORM_MENU_ID = "FORM_MENU_ID";
+  private static final String FORM_URL = "formUrl";
   private static final String WINDOW_TYPE = "windowType";
   private static final String WINDOW_MENU_ID = "WINDOW_MENU_ID";
   private static final String WINDOW_ID = "WINDOW_ID_VAL";
@@ -573,63 +578,42 @@ class MenuBuilderTest {
   }
 
   /**
-   * Tests addViewInfo with a fully qualified classname.
-   * The simple name (after the last dot) must be used as viewId.
+   * Tests addViewInfo across its three derivation paths, all emitting {@code type = "View"}:
+   * a fully qualified classname yields its simple name as viewId; a null classname falls back to
+   * the view name; and an empty query result leaves viewId unset. {@code rowPresent} distinguishes
+   * "a row with a null classname" from "no row at all".
    *
+   * @param rowPresent     Whether the native query returns a view row.
+   * @param className      The classname column of the returned row (null when absent).
+   * @param viewName       The name column of the returned row.
+   * @param expectedViewId The expected viewId, or null when it must be omitted.
    * @throws JSONException if there is an error during JSON construction
    */
-  @Test
-  void testAddViewInfoWithFullyQualifiedClassname() throws JSONException {
+  @ParameterizedTest
+  @CsvSource(nullValues = "NULL", value = {
+      "true, com.example.MyViewClassName, MyViewName, MyViewClassName",
+      "true, NULL, SimpleViewName, SimpleViewName",
+      "false, NULL, NULL, NULL"
+  })
+  void testAddViewInfoDerivesViewId(boolean rowPresent, String className, String viewName,
+      String expectedViewId) throws JSONException {
     MenuOption childOption = mock(MenuOption.class);
     Menu childMenu = mock(Menu.class);
-    setupViewMenuOption(childOption, childMenu, "VIEW_MENU_ID");
-    Object[] viewRow = { "com.example.MyViewClassName", "MyViewName" };
-    setupQueryMock(Collections.singletonList(viewRow));
+    setupViewMenuOption(childOption, childMenu, VIEW_MENU_ID);
+    List<Object[]> rows = rowPresent
+        ? Collections.singletonList(new Object[] { className, viewName })
+        : Collections.emptyList();
+    setupQueryMock(rows);
 
     withMenuBuilderAndDal(builder -> {
       JSONObject result = builder.toJSON();
       JSONObject viewMenu = result.getJSONArray("menu").getJSONObject(0);
       assertEquals("View", viewMenu.getString("type"));
-      assertEquals("MyViewClassName", viewMenu.getString(VIEW_ID));
-    });
-  }
-
-  /**
-   * Tests addViewInfo when classname is null: falls back to the view name.
-   *
-   * @throws JSONException if there is an error during JSON construction
-   */
-  @Test
-  void testAddViewInfoFallsBackToNameWhenClassnameIsNull() throws JSONException {
-    MenuOption childOption = mock(MenuOption.class);
-    Menu childMenu = mock(Menu.class);
-    setupViewMenuOption(childOption, childMenu, "VIEW_MENU_ID_2");
-    Object[] viewRow = { null, "SimpleViewName" };
-    setupQueryMock(Collections.singletonList(viewRow));
-
-    withMenuBuilderAndDal(builder -> {
-      JSONObject result = builder.toJSON();
-      JSONObject viewMenu = result.getJSONArray("menu").getJSONObject(0);
-      assertEquals("SimpleViewName", viewMenu.getString(VIEW_ID));
-    });
-  }
-
-  /**
-   * Tests addViewInfo when no view data is found: viewId must not be set.
-   *
-   * @throws JSONException if there is an error during JSON construction
-   */
-  @Test
-  void testAddViewInfoWithEmptyResultDoesNotSetViewId() throws JSONException {
-    MenuOption childOption = mock(MenuOption.class);
-    Menu childMenu = mock(Menu.class);
-    setupViewMenuOption(childOption, childMenu, "VIEW_MENU_ID_3");
-    setupQueryMock(Collections.emptyList());
-
-    withMenuBuilderAndDal(builder -> {
-      JSONObject result = builder.toJSON();
-      JSONObject viewMenu = result.getJSONArray("menu").getJSONObject(0);
-      assertFalse(viewMenu.has(VIEW_ID));
+      if (expectedViewId == null) {
+        assertFalse(viewMenu.has(VIEW_ID));
+      } else {
+        assertEquals(expectedViewId, viewMenu.getString(VIEW_ID));
+      }
     });
   }
 
@@ -638,136 +622,50 @@ class MenuBuilderTest {
   // -------------------------------------------------------------------------
 
   /**
-   * Tests addFormInfo with a fully qualified Java class name.
-   * The simple class name (after the last dot) must be used in the formUrl.
+   * Tests addFormInfo across its Java-class-name derivation paths: a fully qualified name and a
+   * simple name both yield a {@code /ad_forms/<SimpleName>.html} formUrl, while a null or empty
+   * class name sets only formId and omits formUrl. {@code formId} is always emitted verbatim.
    *
+   * @param javaClassName   The form's Java class name (null/empty for the formId-only cases).
+   * @param formId          The form id, expected verbatim in the JSON.
+   * @param expectedFormUrl The expected formUrl, or null when it must be omitted.
    * @throws JSONException if there is an error during JSON construction
    */
-  @Test
-  void testAddFormInfoWithFullyQualifiedClassName() throws JSONException {
+  @ParameterizedTest
+  @CsvSource(nullValues = "NULL", value = {
+      "org.openbravo.erpCommon.ad_forms.SomeForm, FORM_ABC_123, /ad_forms/SomeForm.html",
+      "SimpleFormClass, FORM_SIMPLE_456, /ad_forms/SimpleFormClass.html",
+      "NULL, FORM_NULL_789, NULL",
+      "'', FORM_EMPTY_000, NULL"
+  })
+  void testAddFormInfoDerivesFormUrlFromJavaClassName(String javaClassName, String formId,
+      String expectedFormUrl) throws JSONException {
     MenuOption childOption = mock(MenuOption.class);
     Menu childMenu = mock(Menu.class);
     Form mockForm = mock(Form.class);
-    String menuId = "FORM_FQ_ID";
 
     when(rootMenuOption.getChildren()).thenReturn(List.of(childOption));
     when(childOption.getMenu()).thenReturn(childMenu);
     when(childOption.getType()).thenReturn(MenuManager.MenuEntryType.External);
-    when(childMenu.getId()).thenReturn(menuId);
-    when(childMenu.get(Menu.PROPERTY_ETMETAICON, language, menuId)).thenReturn(FORM_ICON);
-    when(childMenu.get(Menu.PROPERTY_NAME, language, menuId)).thenReturn("Form Menu");
-    when(childMenu.get(Menu.PROPERTY_DESCRIPTION, language, menuId)).thenReturn("Form Desc");
+    when(childMenu.getId()).thenReturn(FORM_MENU_ID);
+    when(childMenu.get(Menu.PROPERTY_ETMETAICON, language, FORM_MENU_ID)).thenReturn(FORM_ICON);
+    when(childMenu.get(Menu.PROPERTY_NAME, language, FORM_MENU_ID)).thenReturn("Form Menu");
+    when(childMenu.get(Menu.PROPERTY_DESCRIPTION, language, FORM_MENU_ID)).thenReturn("Form Desc");
     when(childMenu.getURL()).thenReturn("/form/url");
     when(childMenu.getAction()).thenReturn("F");
     when(childMenu.getSpecialForm()).thenReturn(mockForm);
-    when(mockForm.getId()).thenReturn("FORM_ABC_123");
-    when(mockForm.getJavaClassName()).thenReturn("org.openbravo.erpCommon.ad_forms.SomeForm");
+    when(mockForm.getId()).thenReturn(formId);
+    when(mockForm.getJavaClassName()).thenReturn(javaClassName);
 
     withMenuBuilder(builder -> {
       JSONObject result = builder.toJSON();
       JSONObject formMenu = result.getJSONArray("menu").getJSONObject(0);
-      assertEquals("FORM_ABC_123", formMenu.getString(FORM_ID));
-      assertEquals("/ad_forms/SomeForm.html", formMenu.getString("formUrl"));
-    });
-  }
-
-  /**
-   * Tests addFormInfo with a simple class name (no package prefix).
-   * The class name itself must be used directly in the formUrl path.
-   *
-   * @throws JSONException if there is an error during JSON construction
-   */
-  @Test
-  void testAddFormInfoWithSimpleClassName() throws JSONException {
-    MenuOption childOption = mock(MenuOption.class);
-    Menu childMenu = mock(Menu.class);
-    Form mockForm = mock(Form.class);
-    String menuId = "FORM_SIMPLE_ID";
-
-    when(rootMenuOption.getChildren()).thenReturn(List.of(childOption));
-    when(childOption.getMenu()).thenReturn(childMenu);
-    when(childOption.getType()).thenReturn(MenuManager.MenuEntryType.External);
-    when(childMenu.getId()).thenReturn(menuId);
-    when(childMenu.get(Menu.PROPERTY_ETMETAICON, language, menuId)).thenReturn(FORM_ICON);
-    when(childMenu.get(Menu.PROPERTY_NAME, language, menuId)).thenReturn("Simple Form Menu");
-    when(childMenu.get(Menu.PROPERTY_DESCRIPTION, language, menuId)).thenReturn("Simple Desc");
-    when(childMenu.getURL()).thenReturn("/simple/url");
-    when(childMenu.getAction()).thenReturn("F");
-    when(childMenu.getSpecialForm()).thenReturn(mockForm);
-    when(mockForm.getId()).thenReturn("FORM_SIMPLE_456");
-    when(mockForm.getJavaClassName()).thenReturn("SimpleFormClass");
-
-    withMenuBuilder(builder -> {
-      JSONObject result = builder.toJSON();
-      JSONObject formMenu = result.getJSONArray("menu").getJSONObject(0);
-      assertEquals("FORM_SIMPLE_456", formMenu.getString(FORM_ID));
-      assertEquals("/ad_forms/SimpleFormClass.html", formMenu.getString("formUrl"));
-    });
-  }
-
-  /**
-   * Tests addFormInfo when the form has a null Java class name.
-   * Only formId must be set; formUrl must be absent.
-   *
-   * @throws JSONException if there is an error during JSON construction
-   */
-  @Test
-  void testAddFormInfoWithNullClassNameSetsOnlyFormId() throws JSONException {
-    MenuOption childOption = mock(MenuOption.class);
-    Menu childMenu = mock(Menu.class);
-    Form mockForm = mock(Form.class);
-    String menuId = "FORM_NULL_CLS_ID";
-
-    when(rootMenuOption.getChildren()).thenReturn(List.of(childOption));
-    when(childOption.getMenu()).thenReturn(childMenu);
-    when(childOption.getType()).thenReturn(MenuManager.MenuEntryType.External);
-    when(childMenu.getId()).thenReturn(menuId);
-    when(childMenu.get(Menu.PROPERTY_ETMETAICON, language, menuId)).thenReturn(FORM_ICON);
-    when(childMenu.get(Menu.PROPERTY_NAME, language, menuId)).thenReturn("Null Class Form");
-    when(childMenu.get(Menu.PROPERTY_DESCRIPTION, language, menuId)).thenReturn("Null Class Desc");
-    when(childMenu.getURL()).thenReturn("/null/url");
-    when(childMenu.getAction()).thenReturn("F");
-    when(childMenu.getSpecialForm()).thenReturn(mockForm);
-    when(mockForm.getId()).thenReturn("FORM_NULL_789");
-    when(mockForm.getJavaClassName()).thenReturn(null);
-
-    withMenuBuilder(builder -> {
-      JSONObject result = builder.toJSON();
-      JSONObject formMenu = result.getJSONArray("menu").getJSONObject(0);
-      assertEquals("FORM_NULL_789", formMenu.getString(FORM_ID));
-    });
-  }
-
-  /**
-   * Tests addFormInfo when the form has an empty Java class name.
-   * Only formId must be set; formUrl must be absent.
-   *
-   * @throws JSONException if there is an error during JSON construction
-   */
-  @Test
-  void testAddFormInfoWithEmptyClassNameSetsOnlyFormId() throws JSONException {
-    MenuOption childOption = mock(MenuOption.class);
-    Menu childMenu = mock(Menu.class);
-    Form mockForm = mock(Form.class);
-    String menuId = "FORM_EMPTY_CLS_ID";
-
-    when(rootMenuOption.getChildren()).thenReturn(List.of(childOption));
-    when(childOption.getMenu()).thenReturn(childMenu);
-    when(childOption.getType()).thenReturn(MenuManager.MenuEntryType.External);
-    when(childMenu.getId()).thenReturn(menuId);
-    when(childMenu.get(Menu.PROPERTY_ETMETAICON, language, menuId)).thenReturn(FORM_ICON);
-    when(childMenu.get(Menu.PROPERTY_NAME, language, menuId)).thenReturn("Empty Class Form");
-    when(childMenu.get(Menu.PROPERTY_DESCRIPTION, language, menuId)).thenReturn("Empty Class Desc");
-    when(childMenu.getURL()).thenReturn("/empty/url");
-    when(childMenu.getAction()).thenReturn("F");
-    when(childMenu.getSpecialForm()).thenReturn(mockForm);
-    when(mockForm.getId()).thenReturn("FORM_EMPTY_000");
-    when(mockForm.getJavaClassName()).thenReturn("");
-
-    withMenuBuilder(builder -> {
-      JSONObject result = builder.toJSON();
-      JSONObject formMenu = result.getJSONArray("menu").getJSONObject(0);
-      assertEquals("FORM_EMPTY_000", formMenu.getString(FORM_ID));
+      assertEquals(formId, formMenu.getString(FORM_ID));
+      if (expectedFormUrl == null) {
+        assertFalse(formMenu.has(FORM_URL));
+      } else {
+        assertEquals(expectedFormUrl, formMenu.getString(FORM_URL));
+      }
     });
   }
 

--- a/src-test/src/com/etendoerp/metadata/builders/MenuBuilderTest.java
+++ b/src-test/src/com/etendoerp/metadata/builders/MenuBuilderTest.java
@@ -23,15 +23,20 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -45,6 +50,7 @@ import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
 import org.hibernate.Session;
 import org.hibernate.query.NativeQuery;
+import org.hibernate.query.Query;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -58,6 +64,7 @@ import org.openbravo.client.application.MenuManager.MenuOption;
 import org.openbravo.dal.core.OBContext;
 import org.openbravo.dal.service.OBDal;
 import org.openbravo.erpCommon.utility.Utility;
+import org.openbravo.model.ad.access.Role;
 import org.openbravo.model.ad.domain.ModelImplementation;
 import org.openbravo.model.ad.domain.ModelImplementationMapping;
 import org.openbravo.model.ad.system.Language;
@@ -89,6 +96,11 @@ class MenuBuilderTest {
   @Mock
   private OBDal obDal;
 
+  @Mock
+  private Role role;
+
+  private static final String TEST_ROLE_ID = "TEST_ROLE_ID";
+  private static final String TEST_LANG_ID = "TEST_LANG_ID";
   private static final String PROCESS_URL = "processUrl";
   private static final String PROCESS_ID = "processId";
   private static final String IS_REPORT = "isReport";
@@ -126,14 +138,31 @@ class MenuBuilderTest {
     Field managerField = MenuBuilder.class.getDeclaredField("manager");
     managerField.setAccessible(true);
     ((ThreadLocal<?>) managerField.get(null)).remove();
+    MenuBuilder.clearMenuCache();
+  }
+
+  /**
+   * Wires the shared OBContext stubs used by every builder helper: the static
+   * {@code getOBContext()} accessor, the language (read by the {@code Builder} superclass
+   * constructor) and the role/language identifiers used to compose the menu cache key. The
+   * role and identifier stubs are lenient because constructor-only tests never reach the
+   * cache-key path.
+   *
+   * @param obContextStatic The mocked static OBContext.
+   */
+  private void stubContext(MockedStatic<OBContext> obContextStatic) {
+    obContextStatic.when(OBContext::getOBContext).thenReturn(obContext);
+    when(obContext.getLanguage()).thenReturn(language);
+    lenient().when(obContext.getRole()).thenReturn(role);
+    lenient().when(role.getId()).thenReturn(TEST_ROLE_ID);
+    lenient().when(language.getId()).thenReturn(TEST_LANG_ID);
   }
 
   private void withMenuBuilder(MenuBuilderConsumer action) throws JSONException {
     try (MockedStatic<OBContext> obContextStatic = mockStatic(OBContext.class);
         MockedConstruction<MenuManager> ignored = mockConstruction(MenuManager.class,
             (mock, context) -> when(mock.getMenu()).thenReturn(rootMenuOption))) {
-      obContextStatic.when(OBContext::getOBContext).thenReturn(obContext);
-      when(obContext.getLanguage()).thenReturn(language);
+      stubContext(obContextStatic);
       action.accept(new MenuBuilder());
     }
   }
@@ -141,10 +170,11 @@ class MenuBuilderTest {
   private void withMenuBuilderAndUtility(MenuBuilderConsumer action) throws JSONException {
     try (MockedStatic<OBContext> obContextStatic = mockStatic(OBContext.class);
         MockedStatic<Utility> ignoredUtility = mockStatic(Utility.class);
+        MockedStatic<OBDal> dalStatic = mockStatic(OBDal.class);
         MockedConstruction<MenuManager> ignored = mockConstruction(MenuManager.class,
             (mock, context) -> when(mock.getMenu()).thenReturn(rootMenuOption))) {
-      obContextStatic.when(OBContext::getOBContext).thenReturn(obContext);
-      when(obContext.getLanguage()).thenReturn(language);
+      stubContext(obContextStatic);
+      dalStatic.when(OBDal::getInstance).thenReturn(obDal);
       action.accept(new MenuBuilder());
     }
   }
@@ -154,11 +184,45 @@ class MenuBuilderTest {
         MockedStatic<OBDal> dalStatic = mockStatic(OBDal.class);
         MockedConstruction<MenuManager> ignored = mockConstruction(MenuManager.class,
             (mock, context) -> when(mock.getMenu()).thenReturn(rootMenuOption))) {
-      obContextStatic.when(OBContext::getOBContext).thenReturn(obContext);
-      when(obContext.getLanguage()).thenReturn(language);
+      stubContext(obContextStatic);
       dalStatic.when(OBDal::getInstance).thenReturn(obDal);
       action.accept(new MenuBuilder());
     }
+  }
+
+  /**
+   * Stubs the raw Hibernate query used by {@code MenuBuilder.loadDefaultMappings()} so it
+   * returns the supplied default mappings. Mirrors the batch-load path (a single typed
+   * {@code createQuery(...).list()}), which replaces the previous per-process lazy iteration.
+   *
+   * @param mappings The default mappings the query must return.
+   */
+  @SuppressWarnings("unchecked")
+  private void setupDefaultMappingsQuery(List<ModelImplementationMapping> mappings) {
+    Query<ModelImplementationMapping> mappingsQuery = mock(Query.class);
+    when(obDal.getSession()).thenReturn(session);
+    when(session.createQuery(anyString(), eq(ModelImplementationMapping.class))).thenReturn(mappingsQuery);
+    when(mappingsQuery.list()).thenReturn(mappings);
+  }
+
+  /**
+   * Builds a default {@link ModelImplementationMapping} mock wired to the given process id and
+   * mapping name, replicating the {@code modelObject.process.id} navigation that
+   * {@code loadDefaultMappings()} uses to index the mapping.
+   *
+   * @param processId   The owning process id.
+   * @param mappingName The mapping name (used as the process URL).
+   * @return The configured mapping mock.
+   */
+  private ModelImplementationMapping mockDefaultMapping(String processId, String mappingName) {
+    ModelImplementationMapping mim = mock(ModelImplementationMapping.class);
+    ModelImplementation mi = mock(ModelImplementation.class);
+    org.openbravo.model.ad.ui.Process owner = mock(org.openbravo.model.ad.ui.Process.class);
+    when(mim.getModelObject()).thenReturn(mi);
+    when(mi.getProcess()).thenReturn(owner);
+    when(owner.getId()).thenReturn(processId);
+    lenient().when(mim.getMappingName()).thenReturn(mappingName);
+    return mim;
   }
 
   private void setupViewMenuOption(MenuOption childOption, Menu childMenu, String menuId) {
@@ -309,8 +373,6 @@ class MenuBuilderTest {
     MenuOption childOption = mock(MenuOption.class);
     Menu childMenu = mock(Menu.class);
     org.openbravo.model.ad.ui.Process process = mock(org.openbravo.model.ad.ui.Process.class);
-    ModelImplementation mi = mock(ModelImplementation.class);
-    ModelImplementationMapping mim = mock(ModelImplementationMapping.class);
 
     when(rootMenuOption.getChildren()).thenReturn(List.of(childOption));
     when(childOption.getMenu()).thenReturn(childMenu);
@@ -322,10 +384,7 @@ class MenuBuilderTest {
     when(process.getId()).thenReturn(AD_PROCESS_ID);
     when(process.isActive()).thenReturn(true);
     when(process.getUIPattern()).thenReturn(STANDARD);
-    when(process.getADModelImplementationList()).thenReturn(List.of(mi));
-    when(mi.getADModelImplementationMappingList()).thenReturn(List.of(mim));
-    when(mim.isDefault()).thenReturn(true);
-    when(mim.getMappingName()).thenReturn(MAPPING_URL);
+    setupDefaultMappingsQuery(List.of(mockDefaultMapping(AD_PROCESS_ID, MAPPING_URL)));
 
     withMenuBuilderAndUtility(builder -> {
       JSONObject result = builder.toJSON();
@@ -346,8 +405,6 @@ class MenuBuilderTest {
     MenuOption childOption = mock(MenuOption.class);
     Menu childMenu = mock(Menu.class);
     org.openbravo.model.ad.ui.Process process = mock(org.openbravo.model.ad.ui.Process.class);
-    ModelImplementation mi = mock(ModelImplementation.class);
-    ModelImplementationMapping mim = mock(ModelImplementationMapping.class);
 
     when(rootMenuOption.getChildren()).thenReturn(List.of(childOption));
     when(childOption.getMenu()).thenReturn(childMenu);
@@ -358,10 +415,7 @@ class MenuBuilderTest {
     when(process.getId()).thenReturn(AD_REPORT_ID);
     when(process.isActive()).thenReturn(true);
     when(process.isReport()).thenReturn(true);
-    when(process.getADModelImplementationList()).thenReturn(List.of(mi));
-    when(mi.getADModelImplementationMappingList()).thenReturn(List.of(mim));
-    when(mim.isDefault()).thenReturn(true);
-    when(mim.getMappingName()).thenReturn(REPORT_URL);
+    setupDefaultMappingsQuery(List.of(mockDefaultMapping(AD_REPORT_ID, REPORT_URL)));
 
     withMenuBuilderAndUtility(builder -> {
       JSONObject result = builder.toJSON();
@@ -393,12 +447,108 @@ class MenuBuilderTest {
     when(process.isActive()).thenReturn(true);
     when(process.isExternalService()).thenReturn(true);
     when(process.getServiceType()).thenReturn("PS");
-    when(process.getADModelImplementationList()).thenReturn(new ArrayList<>());
+    setupDefaultMappingsQuery(Collections.emptyList());
 
     withMenuBuilderAndUtility(builder -> {
       JSONObject result = builder.toJSON();
       JSONObject pentahoMenu = result.getJSONArray("menu").getJSONObject(0);
       assertEquals(PENTAHO_URL + AD_PENTAHO_ID, pentahoMenu.getString(PROCESS_URL));
+    });
+  }
+
+  /**
+   * Builds a Standard, active process menu entry wired to the given menu and process ids.
+   * Centralises the boilerplate shared by the batch-loading tests.
+   *
+   * @param menuId    The menu entry id.
+   * @param processId The process id.
+   * @return The configured MenuOption.
+   */
+  private MenuOption mockProcessEntry(String menuId, String processId) {
+    MenuOption option = mock(MenuOption.class);
+    Menu menu = mock(Menu.class);
+    org.openbravo.model.ad.ui.Process process = mock(org.openbravo.model.ad.ui.Process.class);
+    when(option.getMenu()).thenReturn(menu);
+    when(option.getType()).thenReturn(MenuManager.MenuEntryType.Process);
+    when(menu.getId()).thenReturn(menuId);
+    when(menu.getProcess()).thenReturn(process);
+    when(process.getId()).thenReturn(processId);
+    when(process.isActive()).thenReturn(true);
+    when(process.getUIPattern()).thenReturn(STANDARD);
+    return option;
+  }
+
+  /**
+   * Verifies the N+1 fix: resolving default mappings for several process entries executes the
+   * batch query exactly once (it is loaded lazily on the first process and memoised), instead of
+   * one lazy load per process. The batch runs on the raw Hibernate session, which applies no
+   * active/client/organization filter, matching the original lazy-collection semantics.
+   *
+   * @throws JSONException if there is an error during JSON construction
+   */
+  @Test
+  void testDefaultMappingsQueryRunsOnceForMultipleProcesses() throws JSONException {
+    MenuOption firstProcess = mockProcessEntry("MENU_1", "PROC_1");
+    MenuOption secondProcess = mockProcessEntry("MENU_2", "PROC_2");
+    when(rootMenuOption.getChildren()).thenReturn(List.of(firstProcess, secondProcess));
+    setupDefaultMappingsQuery(
+        List.of(mockDefaultMapping("PROC_1", MAPPING_URL), mockDefaultMapping("PROC_2", REPORT_URL)));
+
+    withMenuBuilderAndUtility(builder -> {
+      builder.toJSON();
+      verify(session, times(1)).createQuery(anyString(), eq(ModelImplementationMapping.class));
+    });
+  }
+
+  /**
+   * Verifies that a second build for the same role and language is served from the cache: the
+   * cached JSON instance is returned verbatim rather than rebuilt.
+   *
+   * @throws JSONException if there is an error during JSON construction
+   */
+  @Test
+  void testCacheHitReturnsSameMenuInstance() throws JSONException {
+    when(rootMenuOption.getChildren()).thenReturn(Collections.emptyList());
+
+    withMenuBuilder(builder -> {
+      JSONObject first = builder.toJSON();
+      JSONObject second = builder.toJSON();
+      assertSame(first, second);
+    });
+  }
+
+  /**
+   * Verifies that a different role produces a different cache key and therefore a freshly built
+   * menu (cache miss), so roles never share cached menus.
+   *
+   * @throws JSONException if there is an error during JSON construction
+   */
+  @Test
+  void testCacheMissForDifferentRoleRebuildsMenu() throws JSONException {
+    when(rootMenuOption.getChildren()).thenReturn(Collections.emptyList());
+
+    withMenuBuilder(builder -> {
+      when(role.getId()).thenReturn("ROLE_A", "ROLE_B");
+      JSONObject first = builder.toJSON();
+      JSONObject second = builder.toJSON();
+      assertNotSame(first, second);
+    });
+  }
+
+  /**
+   * Verifies that clearing the menu cache forces the next build to reconstruct the JSON.
+   *
+   * @throws JSONException if there is an error during JSON construction
+   */
+  @Test
+  void testClearMenuCacheForcesRebuild() throws JSONException {
+    when(rootMenuOption.getChildren()).thenReturn(Collections.emptyList());
+
+    withMenuBuilder(builder -> {
+      JSONObject first = builder.toJSON();
+      MenuBuilder.clearMenuCache();
+      JSONObject second = builder.toJSON();
+      assertNotSame(first, second);
     });
   }
 

--- a/src-test/src/com/etendoerp/metadata/builders/MenuBuilderTest.java
+++ b/src-test/src/com/etendoerp/metadata/builders/MenuBuilderTest.java
@@ -30,7 +30,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
@@ -58,6 +57,7 @@ import org.mockito.Mock;
 import org.mockito.MockedConstruction;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.openbravo.base.weld.WeldUtils;
 import org.openbravo.client.application.GlobalMenu;
 import org.openbravo.client.application.MenuManager;
 import org.openbravo.client.application.MenuManager.MenuOption;
@@ -98,6 +98,9 @@ class MenuBuilderTest {
 
   @Mock
   private Role role;
+
+  @Mock
+  private GlobalMenu globalMenu;
 
   private static final String TEST_ROLE_ID = "TEST_ROLE_ID";
   private static final String TEST_LANG_ID = "TEST_LANG_ID";
@@ -158,22 +161,37 @@ class MenuBuilderTest {
     lenient().when(language.getId()).thenReturn(TEST_LANG_ID);
   }
 
+  /**
+   * Stubs the CDI lookup performed by the {@code MenuBuilder} constructor so it resolves to the
+   * shared {@link GlobalMenu} mock instead of hitting the real bean manager.
+   *
+   * @param weldStatic The mocked static WeldUtils.
+   */
+  private void stubWeld(MockedStatic<WeldUtils> weldStatic) {
+    weldStatic.when(() -> WeldUtils.getInstanceFromStaticBeanManager(GlobalMenu.class))
+        .thenReturn(globalMenu);
+  }
+
   private void withMenuBuilder(MenuBuilderConsumer action) throws JSONException {
     try (MockedStatic<OBContext> obContextStatic = mockStatic(OBContext.class);
+        MockedStatic<WeldUtils> weldStatic = mockStatic(WeldUtils.class);
         MockedConstruction<MenuManager> ignored = mockConstruction(MenuManager.class,
             (mock, context) -> when(mock.getMenu()).thenReturn(rootMenuOption))) {
       stubContext(obContextStatic);
+      stubWeld(weldStatic);
       action.accept(new MenuBuilder());
     }
   }
 
   private void withMenuBuilderAndUtility(MenuBuilderConsumer action) throws JSONException {
     try (MockedStatic<OBContext> obContextStatic = mockStatic(OBContext.class);
+        MockedStatic<WeldUtils> weldStatic = mockStatic(WeldUtils.class);
         MockedStatic<Utility> ignoredUtility = mockStatic(Utility.class);
         MockedStatic<OBDal> dalStatic = mockStatic(OBDal.class);
         MockedConstruction<MenuManager> ignored = mockConstruction(MenuManager.class,
             (mock, context) -> when(mock.getMenu()).thenReturn(rootMenuOption))) {
       stubContext(obContextStatic);
+      stubWeld(weldStatic);
       dalStatic.when(OBDal::getInstance).thenReturn(obDal);
       action.accept(new MenuBuilder());
     }
@@ -181,10 +199,12 @@ class MenuBuilderTest {
 
   private void withMenuBuilderAndDal(MenuBuilderConsumer action) throws JSONException {
     try (MockedStatic<OBContext> obContextStatic = mockStatic(OBContext.class);
+        MockedStatic<WeldUtils> weldStatic = mockStatic(WeldUtils.class);
         MockedStatic<OBDal> dalStatic = mockStatic(OBDal.class);
         MockedConstruction<MenuManager> ignored = mockConstruction(MenuManager.class,
             (mock, context) -> when(mock.getMenu()).thenReturn(rootMenuOption))) {
       stubContext(obContextStatic);
+      stubWeld(weldStatic);
       dalStatic.when(OBDal::getInstance).thenReturn(obDal);
       action.accept(new MenuBuilder());
     }
@@ -256,25 +276,25 @@ class MenuBuilderTest {
   }
 
   /**
-   * Test constructor of MenuBuilder when MenuManager throws a
-   * NullPointerException.
-   * This test ensures that the MenuBuilder can still be constructed even if the
-   * MenuManager throws a NullPointerException, which is a common scenario in
-   * real-world applications.
+   * Verifies that the constructor points the MenuManager at the shared, CDI-managed
+   * {@link GlobalMenu} singleton (resolved via {@link WeldUtils}) rather than a per-thread
+   * instance. Sharing the singleton is what lets the classic menu-cache invalidation reach the
+   * tree the new-UI menu is rebuilt from, so a renamed window/menu is reflected on any thread.
    */
   @Test
-  void testConstructorWithNullPointerException() {
+  void testConstructorUsesSharedGlobalMenuSingleton() {
     try (MockedStatic<OBContext> obContextStatic = mockStatic(OBContext.class);
-        MockedConstruction<MenuManager> ignored = mockConstruction(MenuManager.class,
-            (mock, context) -> {
-              when(mock.getMenu()).thenThrow(new NullPointerException());
-              doNothing().when(mock).setGlobalMenuOptions(any(GlobalMenu.class));
-            })) {
+        MockedStatic<WeldUtils> weldStatic = mockStatic(WeldUtils.class);
+        MockedConstruction<MenuManager> managerConstruction = mockConstruction(MenuManager.class)) {
 
       obContextStatic.when(OBContext::getOBContext).thenReturn(obContext);
       when(obContext.getLanguage()).thenReturn(language);
+      stubWeld(weldStatic);
 
-      assertDoesNotThrow(MenuBuilder::new);
+      new MenuBuilder();
+
+      MenuManager constructedManager = managerConstruction.constructed().get(0);
+      verify(constructedManager).setGlobalMenuOptions(globalMenu);
     }
   }
 

--- a/src-test/src/com/etendoerp/metadata/cache/MenuCacheInvalidationObserverTest.java
+++ b/src-test/src/com/etendoerp/metadata/cache/MenuCacheInvalidationObserverTest.java
@@ -16,6 +16,9 @@
  */
 package com.etendoerp.metadata.cache;
 
+import static com.etendoerp.metadata.cache.PersistenceEventTestFactory.deleteEvent;
+import static com.etendoerp.metadata.cache.PersistenceEventTestFactory.newEvent;
+import static com.etendoerp.metadata.cache.PersistenceEventTestFactory.updateEvent;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.mockito.Mockito.mock;
@@ -32,10 +35,6 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.openbravo.base.model.Entity;
 import org.openbravo.base.model.ModelProvider;
-import org.openbravo.base.structure.BaseOBObject;
-import org.openbravo.client.kernel.event.EntityDeleteEvent;
-import org.openbravo.client.kernel.event.EntityNewEvent;
-import org.openbravo.client.kernel.event.EntityUpdateEvent;
 import org.openbravo.dal.core.TriggerHandler;
 
 import com.etendoerp.metadata.builders.MenuBuilder;
@@ -67,7 +66,7 @@ class MenuCacheInvalidationObserverTest {
       MenuCacheInvalidationObserver observer = new MenuCacheInvalidationObserver();
       Entity observedEntity = observer.getObservedEntities()[0];
 
-      observer.onNew(createNewEvent(observedEntity));
+      observer.onNew(newEvent(observedEntity));
 
       menuBuilderMock.verify(MenuBuilder::clearMenuCache, times(1));
     }
@@ -85,7 +84,7 @@ class MenuCacheInvalidationObserverTest {
       MenuCacheInvalidationObserver observer = new MenuCacheInvalidationObserver();
       Entity observedEntity = observer.getObservedEntities()[0];
 
-      observer.onUpdate(createUpdateEvent(observedEntity));
+      observer.onUpdate(updateEvent(observedEntity));
 
       menuBuilderMock.verify(MenuBuilder::clearMenuCache, times(1));
     }
@@ -103,7 +102,7 @@ class MenuCacheInvalidationObserverTest {
       MenuCacheInvalidationObserver observer = new MenuCacheInvalidationObserver();
       Entity observedEntity = observer.getObservedEntities()[0];
 
-      observer.onDelete(createDeleteEvent(observedEntity));
+      observer.onDelete(deleteEvent(observedEntity));
 
       menuBuilderMock.verify(MenuBuilder::clearMenuCache, times(1));
     }
@@ -122,7 +121,7 @@ class MenuCacheInvalidationObserverTest {
       MenuCacheInvalidationObserver observer = new MenuCacheInvalidationObserver();
       Entity observedEntity = observer.getObservedEntities()[0];
 
-      observer.onNew(createNewEvent(observedEntity));
+      observer.onNew(newEvent(observedEntity));
 
       menuBuilderMock.verify(MenuBuilder::clearMenuCache, never());
     }
@@ -139,7 +138,7 @@ class MenuCacheInvalidationObserverTest {
 
       MenuCacheInvalidationObserver observer = new MenuCacheInvalidationObserver();
 
-      observer.onNew(createNewEvent(mock(Entity.class)));
+      observer.onNew(newEvent(mock(Entity.class)));
 
       menuBuilderMock.verify(MenuBuilder::clearMenuCache, never());
     }
@@ -180,29 +179,5 @@ class MenuCacheInvalidationObserverTest {
     TriggerHandler mockTriggerHandler = mock(TriggerHandler.class);
     triggerMock.when(TriggerHandler::getInstance).thenReturn(mockTriggerHandler);
     when(mockTriggerHandler.isDisabled()).thenReturn(false);
-  }
-
-  private EntityNewEvent createNewEvent(Entity targetEntity) {
-    EntityNewEvent event = mock(EntityNewEvent.class);
-    BaseOBObject targetInstance = mock(BaseOBObject.class);
-    when(event.getTargetInstance()).thenReturn(targetInstance);
-    when(targetInstance.getEntity()).thenReturn(targetEntity);
-    return event;
-  }
-
-  private EntityUpdateEvent createUpdateEvent(Entity targetEntity) {
-    EntityUpdateEvent event = mock(EntityUpdateEvent.class);
-    BaseOBObject targetInstance = mock(BaseOBObject.class);
-    when(event.getTargetInstance()).thenReturn(targetInstance);
-    when(targetInstance.getEntity()).thenReturn(targetEntity);
-    return event;
-  }
-
-  private EntityDeleteEvent createDeleteEvent(Entity targetEntity) {
-    EntityDeleteEvent event = mock(EntityDeleteEvent.class);
-    BaseOBObject targetInstance = mock(BaseOBObject.class);
-    when(event.getTargetInstance()).thenReturn(targetInstance);
-    when(targetInstance.getEntity()).thenReturn(targetEntity);
-    return event;
   }
 }

--- a/src-test/src/com/etendoerp/metadata/cache/MenuCacheInvalidationObserverTest.java
+++ b/src-test/src/com/etendoerp/metadata/cache/MenuCacheInvalidationObserverTest.java
@@ -1,0 +1,208 @@
+/*
+ *************************************************************************
+ * The contents of this file are subject to the Etendo License
+ * (the "License"), you may not use this file except in compliance with
+ * the License.
+ * You may obtain a copy of the License at
+ * https://github.com/etendosoftware/etendo_core/blob/main/legal/Etendo_license.txt
+ * Software distributed under the License is distributed on an
+ * "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing rights
+ * and limitations under the License.
+ * All portions are Copyright © 2021-2026 FUTIT SERVICES, S.L
+ * All Rights Reserved.
+ * Contributor(s): Futit Services S.L.
+ *************************************************************************
+ */
+package com.etendoerp.metadata.cache;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.openbravo.base.model.Entity;
+import org.openbravo.base.model.ModelProvider;
+import org.openbravo.base.structure.BaseOBObject;
+import org.openbravo.client.kernel.event.EntityDeleteEvent;
+import org.openbravo.client.kernel.event.EntityNewEvent;
+import org.openbravo.client.kernel.event.EntityUpdateEvent;
+import org.openbravo.dal.core.TriggerHandler;
+
+import com.etendoerp.metadata.builders.MenuBuilder;
+
+/**
+ * Unit tests for {@link MenuCacheInvalidationObserver}.
+ * Verifies that persistence events on menu-composing entities invalidate the menu cache.
+ */
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ExtendWith(MockitoExtension.class)
+class MenuCacheInvalidationObserverTest {
+
+  private static final String[] OBSERVED_TABLE_IDS = {
+      "116", "289",
+      "105", "79127717F4514B459D9014C91E793CE9", "376", "284", "FF80818132D7FB620132D8129D1A0028",
+      "201", "E6F29F8A30BC4603B1D1195051C4F3A6", "378", "197", "FF80818132D85DB50132D860924E0004",
+      "800148", "800149"
+  };
+
+  @Test
+  void onNewInvalidatesMenuCacheForValidEvent() {
+    try (
+        MockedStatic<ModelProvider> modelProviderMock = mockStatic(ModelProvider.class);
+        MockedStatic<TriggerHandler> triggerMock = mockStatic(TriggerHandler.class);
+        MockedStatic<MenuBuilder> menuBuilderMock = mockStatic(MenuBuilder.class)
+    ) {
+      setupMocks(modelProviderMock, triggerMock);
+
+      MenuCacheInvalidationObserver observer = new MenuCacheInvalidationObserver();
+      Entity observedEntity = observer.getObservedEntities()[0];
+
+      observer.onNew(createNewEvent(observedEntity));
+
+      menuBuilderMock.verify(MenuBuilder::clearMenuCache, times(1));
+    }
+  }
+
+  @Test
+  void onUpdateInvalidatesMenuCacheForValidEvent() {
+    try (
+        MockedStatic<ModelProvider> modelProviderMock = mockStatic(ModelProvider.class);
+        MockedStatic<TriggerHandler> triggerMock = mockStatic(TriggerHandler.class);
+        MockedStatic<MenuBuilder> menuBuilderMock = mockStatic(MenuBuilder.class)
+    ) {
+      setupMocks(modelProviderMock, triggerMock);
+
+      MenuCacheInvalidationObserver observer = new MenuCacheInvalidationObserver();
+      Entity observedEntity = observer.getObservedEntities()[0];
+
+      observer.onUpdate(createUpdateEvent(observedEntity));
+
+      menuBuilderMock.verify(MenuBuilder::clearMenuCache, times(1));
+    }
+  }
+
+  @Test
+  void onDeleteInvalidatesMenuCacheForValidEvent() {
+    try (
+        MockedStatic<ModelProvider> modelProviderMock = mockStatic(ModelProvider.class);
+        MockedStatic<TriggerHandler> triggerMock = mockStatic(TriggerHandler.class);
+        MockedStatic<MenuBuilder> menuBuilderMock = mockStatic(MenuBuilder.class)
+    ) {
+      setupMocks(modelProviderMock, triggerMock);
+
+      MenuCacheInvalidationObserver observer = new MenuCacheInvalidationObserver();
+      Entity observedEntity = observer.getObservedEntities()[0];
+
+      observer.onDelete(createDeleteEvent(observedEntity));
+
+      menuBuilderMock.verify(MenuBuilder::clearMenuCache, times(1));
+    }
+  }
+
+  @Test
+  void onNewDoesNotInvalidateWhenTriggersDisabled() {
+    try (
+        MockedStatic<ModelProvider> modelProviderMock = mockStatic(ModelProvider.class);
+        MockedStatic<TriggerHandler> triggerMock = mockStatic(TriggerHandler.class);
+        MockedStatic<MenuBuilder> menuBuilderMock = mockStatic(MenuBuilder.class)
+    ) {
+      setupMocks(modelProviderMock, triggerMock);
+      when(TriggerHandler.getInstance().isDisabled()).thenReturn(true);
+
+      MenuCacheInvalidationObserver observer = new MenuCacheInvalidationObserver();
+      Entity observedEntity = observer.getObservedEntities()[0];
+
+      observer.onNew(createNewEvent(observedEntity));
+
+      menuBuilderMock.verify(MenuBuilder::clearMenuCache, never());
+    }
+  }
+
+  @Test
+  void onNewDoesNotInvalidateForUnobservedEntity() {
+    try (
+        MockedStatic<ModelProvider> modelProviderMock = mockStatic(ModelProvider.class);
+        MockedStatic<TriggerHandler> triggerMock = mockStatic(TriggerHandler.class);
+        MockedStatic<MenuBuilder> menuBuilderMock = mockStatic(MenuBuilder.class)
+    ) {
+      setupMocks(modelProviderMock, triggerMock);
+
+      MenuCacheInvalidationObserver observer = new MenuCacheInvalidationObserver();
+
+      observer.onNew(createNewEvent(mock(Entity.class)));
+
+      menuBuilderMock.verify(MenuBuilder::clearMenuCache, never());
+    }
+  }
+
+  @Test
+  void getObservedEntitiesReturnsAllMenuComposingEntities() {
+    try (
+        MockedStatic<ModelProvider> modelProviderMock = mockStatic(ModelProvider.class);
+        MockedStatic<TriggerHandler> triggerMock = mockStatic(TriggerHandler.class)
+    ) {
+      setupMocks(modelProviderMock, triggerMock);
+
+      MenuCacheInvalidationObserver observer = new MenuCacheInvalidationObserver();
+      Entity[] entities = observer.getObservedEntities();
+
+      assertNotNull(entities);
+      assertEquals(OBSERVED_TABLE_IDS.length, entities.length);
+    }
+  }
+
+  /**
+   * Sets up ModelProvider (returning a distinct Entity mock per observed table id) and
+   * TriggerHandler (enabled) mocks.
+   *
+   * @param modelProviderMock The mocked static ModelProvider.
+   * @param triggerMock       The mocked static TriggerHandler.
+   */
+  private void setupMocks(MockedStatic<ModelProvider> modelProviderMock,
+      MockedStatic<TriggerHandler> triggerMock) {
+    ModelProvider mockProvider = mock(ModelProvider.class);
+    modelProviderMock.when(ModelProvider::getInstance).thenReturn(mockProvider);
+
+    for (String tableId : OBSERVED_TABLE_IDS) {
+      when(mockProvider.getEntityByTableId(tableId)).thenReturn(mock(Entity.class));
+    }
+
+    TriggerHandler mockTriggerHandler = mock(TriggerHandler.class);
+    triggerMock.when(TriggerHandler::getInstance).thenReturn(mockTriggerHandler);
+    when(mockTriggerHandler.isDisabled()).thenReturn(false);
+  }
+
+  private EntityNewEvent createNewEvent(Entity targetEntity) {
+    EntityNewEvent event = mock(EntityNewEvent.class);
+    BaseOBObject targetInstance = mock(BaseOBObject.class);
+    when(event.getTargetInstance()).thenReturn(targetInstance);
+    when(targetInstance.getEntity()).thenReturn(targetEntity);
+    return event;
+  }
+
+  private EntityUpdateEvent createUpdateEvent(Entity targetEntity) {
+    EntityUpdateEvent event = mock(EntityUpdateEvent.class);
+    BaseOBObject targetInstance = mock(BaseOBObject.class);
+    when(event.getTargetInstance()).thenReturn(targetInstance);
+    when(targetInstance.getEntity()).thenReturn(targetEntity);
+    return event;
+  }
+
+  private EntityDeleteEvent createDeleteEvent(Entity targetEntity) {
+    EntityDeleteEvent event = mock(EntityDeleteEvent.class);
+    BaseOBObject targetInstance = mock(BaseOBObject.class);
+    when(event.getTargetInstance()).thenReturn(targetInstance);
+    when(targetInstance.getEntity()).thenReturn(targetEntity);
+    return event;
+  }
+}

--- a/src-test/src/com/etendoerp/metadata/cache/MetadataCacheInvalidationObserverTest.java
+++ b/src-test/src/com/etendoerp/metadata/cache/MetadataCacheInvalidationObserverTest.java
@@ -16,9 +16,11 @@
  */
 package com.etendoerp.metadata.cache;
 
+import static com.etendoerp.metadata.cache.PersistenceEventTestFactory.deleteEvent;
+import static com.etendoerp.metadata.cache.PersistenceEventTestFactory.newEvent;
+import static com.etendoerp.metadata.cache.PersistenceEventTestFactory.updateEvent;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
@@ -33,7 +35,6 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 import org.openbravo.base.model.Entity;
 import org.openbravo.base.model.ModelProvider;
-import org.openbravo.base.structure.BaseOBObject;
 import org.openbravo.client.kernel.event.EntityDeleteEvent;
 import org.openbravo.client.kernel.event.EntityNewEvent;
 import org.openbravo.client.kernel.event.EntityUpdateEvent;
@@ -70,7 +71,7 @@ class MetadataCacheInvalidationObserverTest {
       MetadataCacheInvalidationObserver observer = new MetadataCacheInvalidationObserver();
       Entity observedEntity = observer.getObservedEntities()[0];
 
-      EntityNewEvent event = createNewEvent(observedEntity);
+      EntityNewEvent event = newEvent(observedEntity);
       observer.onNew(event);
 
       tabProcessorMock.verify(TabProcessor::clearFieldCache, times(1));
@@ -94,7 +95,7 @@ class MetadataCacheInvalidationObserverTest {
       MetadataCacheInvalidationObserver observer = new MetadataCacheInvalidationObserver();
       Entity observedEntity = observer.getObservedEntities()[0];
 
-      EntityUpdateEvent event = createUpdateEvent(observedEntity);
+      EntityUpdateEvent event = updateEvent(observedEntity);
       observer.onUpdate(event);
 
       tabProcessorMock.verify(TabProcessor::clearFieldCache, times(1));
@@ -115,7 +116,7 @@ class MetadataCacheInvalidationObserverTest {
       MetadataCacheInvalidationObserver observer = new MetadataCacheInvalidationObserver();
       Entity observedEntity = observer.getObservedEntities()[0];
 
-      EntityDeleteEvent event = createDeleteEvent(observedEntity);
+      EntityDeleteEvent event = deleteEvent(observedEntity);
       observer.onDelete(event);
 
       tabProcessorMock.verify(TabProcessor::clearFieldCache, times(1));
@@ -139,7 +140,7 @@ class MetadataCacheInvalidationObserverTest {
       MetadataCacheInvalidationObserver observer = new MetadataCacheInvalidationObserver();
       Entity observedEntity = observer.getObservedEntities()[0];
 
-      EntityNewEvent event = createNewEvent(observedEntity);
+      EntityNewEvent event = newEvent(observedEntity);
       observer.onNew(event);
 
       tabProcessorMock.verify(TabProcessor::clearFieldCache, never());
@@ -161,7 +162,7 @@ class MetadataCacheInvalidationObserverTest {
 
       MetadataCacheInvalidationObserver observer = new MetadataCacheInvalidationObserver();
 
-      EntityNewEvent event = createNewEvent(unrelatedEntity);
+      EntityNewEvent event = newEvent(unrelatedEntity);
       observer.onNew(event);
 
       tabProcessorMock.verify(TabProcessor::clearFieldCache, never());
@@ -204,29 +205,5 @@ class MetadataCacheInvalidationObserverTest {
     when(mockTriggerHandler.isDisabled()).thenReturn(false);
 
     return entityMocks[0];
-  }
-
-  private EntityNewEvent createNewEvent(Entity targetEntity) {
-    EntityNewEvent event = mock(EntityNewEvent.class);
-    BaseOBObject targetInstance = mock(BaseOBObject.class);
-    when(event.getTargetInstance()).thenReturn(targetInstance);
-    when(targetInstance.getEntity()).thenReturn(targetEntity);
-    return event;
-  }
-
-  private EntityUpdateEvent createUpdateEvent(Entity targetEntity) {
-    EntityUpdateEvent event = mock(EntityUpdateEvent.class);
-    BaseOBObject targetInstance = mock(BaseOBObject.class);
-    when(event.getTargetInstance()).thenReturn(targetInstance);
-    when(targetInstance.getEntity()).thenReturn(targetEntity);
-    return event;
-  }
-
-  private EntityDeleteEvent createDeleteEvent(Entity targetEntity) {
-    EntityDeleteEvent event = mock(EntityDeleteEvent.class);
-    BaseOBObject targetInstance = mock(BaseOBObject.class);
-    when(event.getTargetInstance()).thenReturn(targetInstance);
-    when(targetInstance.getEntity()).thenReturn(targetEntity);
-    return event;
   }
 }

--- a/src-test/src/com/etendoerp/metadata/cache/MetadataCacheManagerTest.java
+++ b/src-test/src/com/etendoerp/metadata/cache/MetadataCacheManagerTest.java
@@ -27,6 +27,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
 import com.etendoerp.metadata.builders.FieldBuilderWithColumn;
+import com.etendoerp.metadata.builders.MenuBuilder;
 import com.etendoerp.metadata.builders.WindowBuilder;
 import com.etendoerp.metadata.data.TabProcessor;
 
@@ -43,7 +44,8 @@ class MetadataCacheManagerTest {
     try (
         MockedStatic<TabProcessor> tabProcessorMock = mockStatic(TabProcessor.class);
         MockedStatic<WindowBuilder> windowBuilderMock = mockStatic(WindowBuilder.class);
-        MockedStatic<FieldBuilderWithColumn> fieldBuilderMock = mockStatic(FieldBuilderWithColumn.class)
+        MockedStatic<FieldBuilderWithColumn> fieldBuilderMock = mockStatic(FieldBuilderWithColumn.class);
+        MockedStatic<MenuBuilder> menuBuilderMock = mockStatic(MenuBuilder.class)
     ) {
       MetadataCacheManager.invalidateAll();
 
@@ -51,6 +53,7 @@ class MetadataCacheManagerTest {
       tabProcessorMock.verify(TabProcessor::clearFieldAccessCache, times(1));
       windowBuilderMock.verify(WindowBuilder::clearTabAllowedCache, times(1));
       fieldBuilderMock.verify(FieldBuilderWithColumn::clearWindowAccessCache, times(1));
+      menuBuilderMock.verify(MenuBuilder::clearMenuCache, times(1));
     }
   }
 
@@ -59,7 +62,8 @@ class MetadataCacheManagerTest {
     try (
         MockedStatic<TabProcessor> tabProcessorMock = mockStatic(TabProcessor.class);
         MockedStatic<WindowBuilder> windowBuilderMock = mockStatic(WindowBuilder.class);
-        MockedStatic<FieldBuilderWithColumn> fieldBuilderMock = mockStatic(FieldBuilderWithColumn.class)
+        MockedStatic<FieldBuilderWithColumn> fieldBuilderMock = mockStatic(FieldBuilderWithColumn.class);
+        MockedStatic<MenuBuilder> menuBuilderMock = mockStatic(MenuBuilder.class)
     ) {
       MetadataCacheManager.invalidateAll();
       MetadataCacheManager.invalidateAll();
@@ -68,6 +72,7 @@ class MetadataCacheManagerTest {
       tabProcessorMock.verify(TabProcessor::clearFieldAccessCache, times(2));
       windowBuilderMock.verify(WindowBuilder::clearTabAllowedCache, times(2));
       fieldBuilderMock.verify(FieldBuilderWithColumn::clearWindowAccessCache, times(2));
+      menuBuilderMock.verify(MenuBuilder::clearMenuCache, times(2));
     }
   }
 }

--- a/src-test/src/com/etendoerp/metadata/cache/PersistenceEventTestFactory.java
+++ b/src-test/src/com/etendoerp/metadata/cache/PersistenceEventTestFactory.java
@@ -1,0 +1,87 @@
+/*
+ *************************************************************************
+ * The contents of this file are subject to the Etendo License
+ * (the "License"), you may not use this file except in compliance with
+ * the License.
+ * You may obtain a copy of the License at
+ * https://github.com/etendosoftware/etendo_core/blob/main/legal/Etendo_license.txt
+ * Software distributed under the License is distributed on an
+ * "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing rights
+ * and limitations under the License.
+ * All portions are Copyright © 2021-2026 FUTIT SERVICES, S.L
+ * All Rights Reserved.
+ * Contributor(s): Futit Services S.L.
+ *************************************************************************
+ */
+package com.etendoerp.metadata.cache;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.openbravo.base.model.Entity;
+import org.openbravo.base.structure.BaseOBObject;
+import org.openbravo.client.kernel.event.EntityDeleteEvent;
+import org.openbravo.client.kernel.event.EntityNewEvent;
+import org.openbravo.client.kernel.event.EntityPersistenceEvent;
+import org.openbravo.client.kernel.event.EntityUpdateEvent;
+
+/**
+ * Shared test factory for the persistence events consumed by the cache-invalidation observers.
+ * Centralises the mock wiring ({@code event.getTargetInstance().getEntity() == targetEntity})
+ * used by both {@link MetadataCacheInvalidationObserverTest} and
+ * {@link MenuCacheInvalidationObserverTest}.
+ */
+final class PersistenceEventTestFactory {
+
+  private PersistenceEventTestFactory() {
+  }
+
+  /**
+   * Builds an {@link EntityNewEvent} whose target instance reports the given entity.
+   *
+   * @param targetEntity The entity the event's target instance must return.
+   * @return The mocked new event.
+   */
+  static EntityNewEvent newEvent(Entity targetEntity) {
+    EntityNewEvent event = mock(EntityNewEvent.class);
+    wireTargetInstance(event, targetEntity);
+    return event;
+  }
+
+  /**
+   * Builds an {@link EntityUpdateEvent} whose target instance reports the given entity.
+   *
+   * @param targetEntity The entity the event's target instance must return.
+   * @return The mocked update event.
+   */
+  static EntityUpdateEvent updateEvent(Entity targetEntity) {
+    EntityUpdateEvent event = mock(EntityUpdateEvent.class);
+    wireTargetInstance(event, targetEntity);
+    return event;
+  }
+
+  /**
+   * Builds an {@link EntityDeleteEvent} whose target instance reports the given entity.
+   *
+   * @param targetEntity The entity the event's target instance must return.
+   * @return The mocked delete event.
+   */
+  static EntityDeleteEvent deleteEvent(Entity targetEntity) {
+    EntityDeleteEvent event = mock(EntityDeleteEvent.class);
+    wireTargetInstance(event, targetEntity);
+    return event;
+  }
+
+  /**
+   * Wires the shared {@code getTargetInstance().getEntity()} stub common to every event type.
+   *
+   * @param event        The mocked persistence event.
+   * @param targetEntity The entity the target instance must return.
+   */
+  private static void wireTargetInstance(EntityPersistenceEvent event, Entity targetEntity) {
+    BaseOBObject targetInstance = mock(BaseOBObject.class);
+    when(event.getTargetInstance()).thenReturn(targetInstance);
+    when(targetInstance.getEntity()).thenReturn(targetEntity);
+  }
+}

--- a/src/com/etendoerp/metadata/builders/MenuBuilder.java
+++ b/src/com/etendoerp/metadata/builders/MenuBuilder.java
@@ -17,7 +17,9 @@
 
 package com.etendoerp.metadata.builders;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.codehaus.jettison.json.JSONException;
@@ -29,7 +31,6 @@ import org.openbravo.client.application.Process;
 import org.openbravo.dal.core.OBContext;
 import org.openbravo.dal.service.OBDal;
 import org.openbravo.erpCommon.utility.Utility;
-import org.openbravo.model.ad.domain.ModelImplementation;
 import org.openbravo.model.ad.domain.ModelImplementationMapping;
 import org.openbravo.model.ad.system.Language;
 import org.openbravo.model.ad.ui.Form;
@@ -37,6 +38,7 @@ import org.openbravo.model.ad.ui.Menu;
 import org.openbravo.model.ad.ui.Window;
 
 import com.etendoerp.metadata.utils.Constants;
+import com.etendoerp.redis.interfaces.CachedConcurrentMap;
 
 /**
  * Builder class for generating Menu metadata in JSON format.
@@ -45,6 +47,14 @@ import com.etendoerp.metadata.utils.Constants;
  */
 public class MenuBuilder extends Builder {
     private static final ThreadLocal<MenuManager> manager = ThreadLocal.withInitial(MenuManager::new);
+
+    private static final String MENU_CACHE = "MENU_METADATA";
+    private static final String CACHE_KEY_SEPARATOR = "_";
+    private static final String DEFAULT_MAPPINGS_HQL = "select mim from ADModelImplementationMapping mim "
+        + "where mim.default = true and mim.modelObject.process is not null";
+    private static final CachedConcurrentMap<String, JSONObject> menuCache = new CachedConcurrentMap<>(MENU_CACHE);
+
+    private Map<String, ModelImplementationMapping> defaultMappingsByProcess;
 
     /**
      * Constructor for MenuBuilder.
@@ -63,6 +73,16 @@ public class MenuBuilder extends Builder {
      */
     public void unload() {
         manager.remove(); // Compliant
+    }
+
+    /**
+     * Clears the cached menu JSON for every role and language. Invoked when Application
+     * Dictionary entities that compose the menu change (see
+     * {@code MenuCacheInvalidationObserver}) or on a full metadata cache reset
+     * (see {@code MetadataCacheManager#invalidateAll()}).
+     */
+    public static void clearMenuCache() {
+        menuCache.clear();
     }
 
     /**
@@ -106,20 +126,40 @@ public class MenuBuilder extends Builder {
     }
 
     /**
-     * Retrieves the default model implementation mapping for a given process.
+     * Retrieves the default model implementation mapping for a given process from the batch
+     * loaded map, resolving it in O(1). The map is loaded lazily on the first process entry
+     * and reused for the rest of the menu, so the whole build performs a single query instead
+     * of the previous per-process N+1 lazy iteration.
      *
      * @param process The process to search for mappings.
      * @return The default ModelImplementationMapping, or null if none is found.
      */
     private ModelImplementationMapping getDefaultMapping(org.openbravo.model.ad.ui.Process process) {
-        for (ModelImplementation mi : process.getADModelImplementationList()) {
-            for (ModelImplementationMapping mim : mi.getADModelImplementationMappingList()) {
-                if (mim.isDefault()) {
-                    return mim;
-                }
-            }
+        if (defaultMappingsByProcess == null) {
+            defaultMappingsByProcess = loadDefaultMappings();
         }
-        return null;
+        return defaultMappingsByProcess.get(process.getId());
+    }
+
+    /**
+     * Loads every default {@link ModelImplementationMapping} in a single query and indexes it
+     * by process id. Uses the raw Hibernate session (as {@link #addViewInfo} does) so no
+     * active/client/organization filter is applied, preserving the semantics of the original
+     * lazy-collection iteration (which included inactive rows). When a process has more than one
+     * default mapping, the first one returned by the query wins, matching the previous
+     * "first default found" behavior.
+     *
+     * @return A map from process id to its default ModelImplementationMapping.
+     */
+    private Map<String, ModelImplementationMapping> loadDefaultMappings() {
+        Map<String, ModelImplementationMapping> result = new HashMap<>();
+        List<ModelImplementationMapping> mappings = OBDal.getInstance().getSession()
+            .createQuery(DEFAULT_MAPPINGS_HQL, ModelImplementationMapping.class)
+            .list();
+        for (ModelImplementationMapping mim : mappings) {
+            result.putIfAbsent(mim.getModelObject().getProcess().getId(), mim);
+        }
+        return result;
     }
 
     /**
@@ -295,17 +335,47 @@ public class MenuBuilder extends Builder {
     }
 
     /**
-     * Generates the complete menu metadata in JSON format.
+     * Generates the complete menu metadata in JSON format. The result is cached per role and
+     * language: on a cache hit the menu tree is not traversed again, avoiding the JSON build
+     * and its per-entry queries.
      *
      * @return A JSONObject containing the menu metadata.
      * @throws JSONException If an error occurs while generating the JSON.
      */
     @Override
     public JSONObject toJSON() throws JSONException {
+        String cacheKey = buildCacheKey(OBContext.getOBContext());
+        JSONObject cached = menuCache.get(cacheKey);
+        if (cached != null) {
+            return cached;
+        }
+        JSONObject result = buildMenuJson();
+        menuCache.put(cacheKey, result);
+        return result;
+    }
+
+    /**
+     * Builds the cache key for the menu JSON. The menu structure depends only on role and
+     * language, so both compose the key.
+     *
+     * @param context The current OB context.
+     * @return The cache key {@code "roleId_languageId"}.
+     */
+    private String buildCacheKey(OBContext context) {
+        return context.getRole().getId() + CACHE_KEY_SEPARATOR + context.getLanguage().getId();
+    }
+
+    /**
+     * Traverses the menu tree and builds its JSON representation. Extracted from
+     * {@link #toJSON()} so the traversal (and its queries) run only on a cache miss.
+     *
+     * @return A JSONObject containing the menu metadata.
+     * @throws JSONException If an error occurs while generating the JSON.
+     */
+    private JSONObject buildMenuJson() throws JSONException {
         JSONObject result = new JSONObject();
         MenuOption menu = manager.get().getMenu();
         result.put("menu", menu.getChildren().stream().map(this::toJSON).collect(Collectors.toList()));
-
         return result;
     }
 }

--- a/src/com/etendoerp/metadata/builders/MenuBuilder.java
+++ b/src/com/etendoerp/metadata/builders/MenuBuilder.java
@@ -69,7 +69,23 @@ public class MenuBuilder extends Builder {
         // tree would go stale and the rebuilt menu JSON would show outdated names/structure depending
         // on which pooled thread served the request. Resolved via WeldUtils because MenuBuilder is
         // instantiated outside a CDI scope that would allow @Inject (same pattern as LabelsBuilder).
-        manager.get().setGlobalMenuOptions(WeldUtils.getInstanceFromStaticBeanManager(GlobalMenu.class));
+        manager.get().setGlobalMenuOptions(resolveGlobalMenu());
+    }
+
+    /**
+     * Resolves the shared CDI {@link GlobalMenu} singleton (the instance the classic menu-cache
+     * invalidation targets). Falls back to a standalone instance only when the CDI container is not
+     * available, e.g. in a unit-test harness where Weld is not bootstrapped; in a running server the
+     * static bean manager is always present, so the shared singleton is always returned.
+     *
+     * @return the CDI-managed GlobalMenu, or a standalone instance when no container is available.
+     */
+    private static GlobalMenu resolveGlobalMenu() {
+        try {
+            return WeldUtils.getInstanceFromStaticBeanManager(GlobalMenu.class);
+        } catch (IllegalStateException e) {
+            return new GlobalMenu();
+        }
     }
 
     /**

--- a/src/com/etendoerp/metadata/builders/MenuBuilder.java
+++ b/src/com/etendoerp/metadata/builders/MenuBuilder.java
@@ -24,6 +24,7 @@ import java.util.stream.Collectors;
 
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
+import org.openbravo.base.weld.WeldUtils;
 import org.openbravo.client.application.GlobalMenu;
 import org.openbravo.client.application.MenuManager;
 import org.openbravo.client.application.MenuManager.MenuOption;
@@ -57,15 +58,18 @@ public class MenuBuilder extends Builder {
     private Map<String, ModelImplementationMapping> defaultMappingsByProcess;
 
     /**
-     * Constructor for MenuBuilder.
-     * Initializes the MenuManager and sets global menu options if necessary.
+     * Constructor for MenuBuilder. Points the thread-local {@link MenuManager} at the shared,
+     * CDI-managed {@link GlobalMenu} singleton so it participates in the standard menu-cache
+     * invalidation.
      */
     public MenuBuilder() {
-        try {
-            manager.get().getMenu();
-        } catch (NullPointerException e) {
-            manager.get().setGlobalMenuOptions(new GlobalMenu());
-        }
+        // Point the (thread-local) MenuManager at the CDI @ApplicationScoped GlobalMenu singleton
+        // (the same instance MenuCacheHandler invalidates) instead of a per-thread new GlobalMenu().
+        // A per-thread instance is invisible to the classic menu-cache invalidation, so its internal
+        // tree would go stale and the rebuilt menu JSON would show outdated names/structure depending
+        // on which pooled thread served the request. Resolved via WeldUtils because MenuBuilder is
+        // instantiated outside a CDI scope that would allow @Inject (same pattern as LabelsBuilder).
+        manager.get().setGlobalMenuOptions(WeldUtils.getInstanceFromStaticBeanManager(GlobalMenu.class));
     }
 
     /**

--- a/src/com/etendoerp/metadata/cache/MenuCacheInvalidationObserver.java
+++ b/src/com/etendoerp/metadata/cache/MenuCacheInvalidationObserver.java
@@ -23,6 +23,7 @@ import org.openbravo.base.model.Entity;
 import org.openbravo.base.model.ModelProvider;
 import org.openbravo.client.kernel.event.EntityDeleteEvent;
 import org.openbravo.client.kernel.event.EntityNewEvent;
+import org.openbravo.client.kernel.event.EntityPersistenceEvent;
 import org.openbravo.client.kernel.event.EntityPersistenceEventObserver;
 import org.openbravo.client.kernel.event.EntityUpdateEvent;
 
@@ -81,20 +82,23 @@ class MenuCacheInvalidationObserver extends EntityPersistenceEventObserver {
       ModelProvider.getInstance().getEntityByTableId(MODEL_OBJECT_MAPPING_TABLE_ID) };
 
   public void onNew(@Observes EntityNewEvent event) {
-    if (!isValidEvent(event)) {
-      return;
-    }
-    MenuBuilder.clearMenuCache();
+    invalidate(event);
   }
 
   public void onUpdate(@Observes EntityUpdateEvent event) {
-    if (!isValidEvent(event)) {
-      return;
-    }
-    MenuBuilder.clearMenuCache();
+    invalidate(event);
   }
 
   public void onDelete(@Observes EntityDeleteEvent event) {
+    invalidate(event);
+  }
+
+  /**
+   * Invalidates the menu cache when the event targets one of the observed entities.
+   *
+   * @param event The persistence event.
+   */
+  private void invalidate(EntityPersistenceEvent event) {
     if (!isValidEvent(event)) {
       return;
     }

--- a/src/com/etendoerp/metadata/cache/MenuCacheInvalidationObserver.java
+++ b/src/com/etendoerp/metadata/cache/MenuCacheInvalidationObserver.java
@@ -1,0 +1,108 @@
+/*
+ *************************************************************************
+ * The contents of this file are subject to the Etendo License
+ * (the "License"), you may not use this file except in compliance with
+ * the License.
+ * You may obtain a copy of the License at
+ * https://github.com/etendosoftware/etendo_core/blob/main/legal/Etendo_license.txt
+ * Software distributed under the License is distributed on an
+ * "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing rights
+ * and limitations under the License.
+ * All portions are Copyright © 2021-2026 FUTIT SERVICES, S.L
+ * All Rights Reserved.
+ * Contributor(s): Futit Services S.L.
+ *************************************************************************
+ */
+
+package com.etendoerp.metadata.cache;
+
+import javax.enterprise.event.Observes;
+
+import org.openbravo.base.model.Entity;
+import org.openbravo.base.model.ModelProvider;
+import org.openbravo.client.kernel.event.EntityDeleteEvent;
+import org.openbravo.client.kernel.event.EntityNewEvent;
+import org.openbravo.client.kernel.event.EntityPersistenceEventObserver;
+import org.openbravo.client.kernel.event.EntityUpdateEvent;
+
+import com.etendoerp.metadata.builders.MenuBuilder;
+
+/**
+ * Observes changes to the Application Dictionary entities that compose the navigation menu and
+ * invalidates the new-UI cached menu JSON ({@link MenuBuilder#clearMenuCache()}).
+ * <p>
+ * Mirrors the entity set of the classic {@code MenuCacheHandler} (Menu, TreeNode, Window, View
+ * Definition, Form, Process, Process Definition and their access records) so the new-UI menu cache
+ * is invalidated in the same situations as the classic {@code GlobalMenu} cache. Additionally it
+ * observes Model Object and Model Object Mapping, because the new-UI menu resolves the default
+ * mapping URL from them (a case the classic handler does not cover).
+ * <p>
+ * The base class {@link EntityPersistenceEventObserver#isValidEvent} already skips events during
+ * bulk imports (when TriggerHandler is disabled).
+ */
+class MenuCacheInvalidationObserver extends EntityPersistenceEventObserver {
+
+  private static final String MENU_TABLE_ID = "116";
+  private static final String TREENODE_TABLE_ID = "289";
+
+  private static final String WINDOW_TABLE_ID = "105";
+  private static final String VIEWDEFINITION_TABLE_ID = "79127717F4514B459D9014C91E793CE9";
+  private static final String FORM_TABLE_ID = "376";
+  private static final String PROCESS_TABLE_ID = "284";
+  private static final String PROCESSDEFINITION_TABLE_ID = "FF80818132D7FB620132D8129D1A0028";
+
+  private static final String WINDOW_ACCESS_TABLE_ID = "201";
+  private static final String VIEWDEFINITION_ACCESS_TABLE_ID = "E6F29F8A30BC4603B1D1195051C4F3A6";
+  private static final String FORM_ACCESS_TABLE_ID = "378";
+  private static final String PROCESS_ACCESS_TABLE_ID = "197";
+  private static final String PROCESSDEFINITION_ACCESS_TABLE_ID = "FF80818132D85DB50132D860924E0004";
+
+  private static final String MODEL_OBJECT_TABLE_ID = "800148";
+  private static final String MODEL_OBJECT_MAPPING_TABLE_ID = "800149";
+
+  private static final Entity[] entities = {
+      ModelProvider.getInstance().getEntityByTableId(MENU_TABLE_ID),
+      ModelProvider.getInstance().getEntityByTableId(TREENODE_TABLE_ID),
+
+      ModelProvider.getInstance().getEntityByTableId(WINDOW_TABLE_ID),
+      ModelProvider.getInstance().getEntityByTableId(VIEWDEFINITION_TABLE_ID),
+      ModelProvider.getInstance().getEntityByTableId(FORM_TABLE_ID),
+      ModelProvider.getInstance().getEntityByTableId(PROCESS_TABLE_ID),
+      ModelProvider.getInstance().getEntityByTableId(PROCESSDEFINITION_TABLE_ID),
+
+      ModelProvider.getInstance().getEntityByTableId(WINDOW_ACCESS_TABLE_ID),
+      ModelProvider.getInstance().getEntityByTableId(VIEWDEFINITION_ACCESS_TABLE_ID),
+      ModelProvider.getInstance().getEntityByTableId(FORM_ACCESS_TABLE_ID),
+      ModelProvider.getInstance().getEntityByTableId(PROCESS_ACCESS_TABLE_ID),
+      ModelProvider.getInstance().getEntityByTableId(PROCESSDEFINITION_ACCESS_TABLE_ID),
+
+      ModelProvider.getInstance().getEntityByTableId(MODEL_OBJECT_TABLE_ID),
+      ModelProvider.getInstance().getEntityByTableId(MODEL_OBJECT_MAPPING_TABLE_ID) };
+
+  public void onNew(@Observes EntityNewEvent event) {
+    if (!isValidEvent(event)) {
+      return;
+    }
+    MenuBuilder.clearMenuCache();
+  }
+
+  public void onUpdate(@Observes EntityUpdateEvent event) {
+    if (!isValidEvent(event)) {
+      return;
+    }
+    MenuBuilder.clearMenuCache();
+  }
+
+  public void onDelete(@Observes EntityDeleteEvent event) {
+    if (!isValidEvent(event)) {
+      return;
+    }
+    MenuBuilder.clearMenuCache();
+  }
+
+  @Override
+  protected Entity[] getObservedEntities() {
+    return entities;
+  }
+}

--- a/src/com/etendoerp/metadata/cache/MetadataCacheManager.java
+++ b/src/com/etendoerp/metadata/cache/MetadataCacheManager.java
@@ -21,6 +21,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
 import com.etendoerp.metadata.builders.FieldBuilderWithColumn;
+import com.etendoerp.metadata.builders.MenuBuilder;
 import com.etendoerp.metadata.builders.WindowBuilder;
 import com.etendoerp.metadata.data.TabProcessor;
 
@@ -36,7 +37,7 @@ public class MetadataCacheManager {
   }
 
   /**
-   * Invalidates all metadata caches: field, field access, tab allowed, and window access.
+   * Invalidates all metadata caches: field, field access, tab allowed, window access, and menu.
    * Called by {@link MetadataCacheInvalidationObserver} when Application Dictionary entities change.
    */
   public static void invalidateAll() {
@@ -45,5 +46,6 @@ public class MetadataCacheManager {
     TabProcessor.clearFieldAccessCache();
     WindowBuilder.clearTabAllowedCache();
     FieldBuilderWithColumn.clearWindowAccessCache();
+    MenuBuilder.clearMenuCache();
   }
 }


### PR DESCRIPTION
### Summary

The endpoint that builds the new-UI menu (`MenuBuilder`) had two inefficiencies:

1. **N+1 queries** when resolving each process's *default mapping*: for every menu item bound to a `Process`, lazy collections (`ModelImplementation` → `ModelImplementationMapping`) were iterated, firing 100+ queries on menus with many processes.
2. **Full JSON rebuild on every request**, even though the result only depends on **role + language**.

### Changes

- **Part 1 — N+1 removal:** default mappings are now resolved with a **single batch query** (`processId → ModelImplementationMapping`), replacing the lazy iteration with an O(1) lookup. The classic behavior's semantics are preserved exactly (same rows, no extra `active` filter, *first-default-wins*).
- **Part 2 — Menu cache by role+language:** the menu JSON is cached (`CachedConcurrentMap`, Redis-aware) with event-driven invalidation, mirroring the entity set already invalidated by the classic `MenuCacheHandler` (Menu, TreeNode, Window, View Definition, Form, Process, Process Definition and their access records) and adding `ModelImplementation` / `ModelImplementationMapping`. On any relevant change the cache is invalidated and the menu reflects the change.

The **menu JSON content and shape remain identical** (full parity with the previous output).

### Performance results

Measured from the client on the request that fetches the menu information:

| Scenario | Server response | Total |
| --- | --- | --- |
| Without changes — subsequent loads | 531.32 ms | 535.31 ms |
| With changes — subsequent loads | 372.72 ms | 375.74 ms |
| **Improvement** | **≈ 30 %** | **≈ 30 %** |

On subsequent loads (warm cache, the common case) there is an **improvement of roughly 30 %** in both server response time and total time. The first load (cold cache) is comparable, since it includes building and populating the cache for the first time.

<!-- Images: upload manually -->

**Without changes — first load**

<img width="1920" height="1080" alt="without-changes-first-time" src="https://github.com/user-attachments/assets/86ae9203-0729-49a8-b24d-902ed717d4d2" />

**Without changes — subsequent loads**

<img width="1920" height="1080" alt="without-changes-other-times" src="https://github.com/user-attachments/assets/11ffa158-7b08-4253-8123-22cb519a9ee3" />

**With changes — first load**

<img width="1920" height="1080" alt="with-changes-first-time" src="https://github.com/user-attachments/assets/d9564f25-ea86-44a9-a3af-fdff662b407a" />

**With changes — subsequent loads**

<img width="1920" height="1080" alt="with-changes-other-times" src="https://github.com/user-attachments/assets/e1888093-9d45-4ec0-b46c-8de433f7db10" />