### PR TITLE
Fix cross-org warehouse in meta/session response

### DIFF
--- a/src/com/etendoerp/metadata/builders/SessionBuilder.java
+++ b/src/com/etendoerp/metadata/builders/SessionBuilder.java
@@ -96,6 +96,8 @@ public class SessionBuilder extends Builder {
             Organization organization = context.getCurrentOrganization();
             Client client = context.getCurrentClient();
             Warehouse warehouse = context.getWarehouse();
+            // ponytail: if warehouse doesn't belong to the resolved org, pick one that does
+            warehouse = validateWarehouseForOrg(warehouse, organization, role);
 
             json.put("user", getJsonObject(user));
             json.put("currentRole", getJsonObject(role));
@@ -264,5 +266,28 @@ public class SessionBuilder extends Builder {
         }
 
         return warehouses;
+    }
+
+    /**
+     * Returns the given warehouse if it belongs to an organization accessible by the role.
+     * Otherwise returns the first valid warehouse for the current organization.
+     * ponytail: guard against cross-org warehouse from stale token, pick org-scoped fallback
+     */
+    private Warehouse validateWarehouseForOrg(Warehouse warehouse, Organization organization, Role role) {
+        if (warehouse == null) {
+            return null;
+        }
+        String whOrgId = warehouse.getOrganization().getId();
+        boolean belongsToRole = role.getADRoleOrganizationList().stream()
+            .anyMatch(ro -> ro.getOrganization().getId().equals(whOrgId));
+        if (belongsToRole) {
+            return warehouse;
+        }
+        // Fallback: first warehouse linked to the current organization
+        List<OrgWarehouse> orgWarehouses = organization.getOrganizationWarehouseList();
+        if (!orgWarehouses.isEmpty()) {
+            return orgWarehouses.get(0).getWarehouse();
+        }
+        return warehouse;
     }
 }


### PR DESCRIPTION
## Summary
- When switching roles, `meta/session` could return a `currentWarehouse` belonging to a different organization than `currentOrganization` (e.g. Spanish org + US warehouse)
- Root cause: `SecureLoginServlet` carries the old token's warehouse into the new token without validating it against the resolved org
- Fix: `SessionBuilder.toJSON()` now validates the warehouse belongs to an org accessible by the current role before returning it; falls back to the first warehouse of the current organization if not

## Test plan
- [ ] Set a US role/org/warehouse as default, save, then switch to a Spanish role — verify `meta/session` returns a Spanish warehouse
- [ ] Set a Spanish role as default, log out/in, switch to US role — verify warehouse matches the US org
- [ ] Verify save-as-default works correctly after the fix
- [ ] Verify no regression when role/org/warehouse are all congruent