### PR TITLE
Hotfix ETP-4370: Fix cross-org warehouse in meta/session

### DIFF
--- a/src-test/src/com/etendoerp/metadata/builders/SessionBuilderTest.java
+++ b/src-test/src/com/etendoerp/metadata/builders/SessionBuilderTest.java
@@ -47,6 +47,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 
 import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
@@ -64,6 +65,7 @@ import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
 import org.openbravo.dal.core.OBContext;
+import org.openbravo.dal.security.OrganizationStructureProvider;
 import org.openbravo.dal.service.OBDal;
 import org.openbravo.erpCommon.utility.DimensionDisplayUtility;
 import org.openbravo.model.ad.access.Role;
@@ -72,7 +74,7 @@ import org.openbravo.model.ad.access.User;
 import org.openbravo.model.ad.access.UserRoles;
 import org.openbravo.model.ad.system.Client;
 import org.openbravo.model.ad.system.Language;
-import org.openbravo.model.common.enterprise.OrgWarehouse;
+
 import org.openbravo.model.common.enterprise.Organization;
 import org.openbravo.model.common.enterprise.Warehouse;
 
@@ -145,16 +147,19 @@ class SessionBuilderTest {
   private Organization org2;
 
   @Mock
-  private OrgWarehouse orgWarehouse1;
-
-  @Mock
-  private OrgWarehouse orgWarehouse2;
-
-  @Mock
   private Warehouse warehouse1;
 
   @Mock
   private Warehouse warehouse2;
+
+  @Mock
+  private Organization warehouseOrg1;
+
+  @Mock
+  private Organization warehouseOrg2;
+
+  @Mock
+  private OrganizationStructureProvider osp;
 
   @Mock
   private OBDal obDal;
@@ -166,7 +171,7 @@ class SessionBuilderTest {
   private Query<UserRoles> rolesQuery;
 
   @Mock
-  private Query<OrgWarehouse> warehousesQuery;
+  private Query<Warehouse> warehousesQuery;
 
   private MockedStatic<OBDal> obDalStatic;
 
@@ -205,11 +210,10 @@ class SessionBuilderTest {
     when(rolesQuery.setParameter(anyString(), any())).thenReturn(rolesQuery);
     when(rolesQuery.list()).thenReturn(Arrays.asList(userRole1, userRole2));
 
-    // Mock the batched warehouses-by-organization query that replaces
-    // organization.getOrganizationWarehouseList()
-    when(session.createQuery(anyString(), eq(OrgWarehouse.class))).thenReturn(warehousesQuery);
+    // Mock the warehouse query (now queries Warehouse directly, not OrgWarehouse)
+    when(session.createQuery(anyString(), eq(Warehouse.class))).thenReturn(warehousesQuery);
     when(warehousesQuery.setParameter(anyString(), any())).thenReturn(warehousesQuery);
-    when(warehousesQuery.list()).thenReturn(Arrays.asList(orgWarehouse1, orgWarehouse2));
+    when(warehousesQuery.list()).thenReturn(Arrays.asList(warehouse1, warehouse2));
 
     // Setup user roles
     when(userRole1.getRole()).thenReturn(role1);
@@ -242,17 +246,22 @@ class SessionBuilderTest {
     when(org2.getId()).thenReturn(ORG2_ID);
     when(org2.get(eq(Organization.PROPERTY_NAME), any(), eq(ORG2_ID))).thenReturn("Organization 2");
 
-    // Setup org warehouses (now resolved through the batched query result, grouped by organization)
-    when(orgWarehouse1.getOrganization()).thenReturn(org1);
-    when(orgWarehouse1.getWarehouse()).thenReturn(warehouse1);
-    when(orgWarehouse2.getOrganization()).thenReturn(org2);
-    when(orgWarehouse2.getWarehouse()).thenReturn(warehouse2);
-
-    // Setup warehouses
+    // Setup warehouses with their owning organizations (for natural tree distribution)
     when(warehouse1.getId()).thenReturn("warehouse1-id");
     when(warehouse1.get(eq(Warehouse.PROPERTY_NAME), any(), eq("warehouse1-id"))).thenReturn("Warehouse 1");
+    when(warehouse1.getOrganization()).thenReturn(warehouseOrg1);
+    when(warehouseOrg1.getId()).thenReturn("org1-id");
+
     when(warehouse2.getId()).thenReturn("warehouse2-id");
     when(warehouse2.get(eq(Warehouse.PROPERTY_NAME), any(), eq("warehouse2-id"))).thenReturn("Warehouse 2");
+    when(warehouse2.getOrganization()).thenReturn(warehouseOrg2);
+    when(warehouseOrg2.getId()).thenReturn(ORG2_ID);
+
+    // Setup OrganizationStructureProvider for natural tree distribution
+    when(obContext.getOrganizationStructureProvider(anyString())).thenReturn(osp);
+    // Each org's natural tree contains its own id (warehouse matches its own org)
+    when(osp.getNaturalTree("org1-id")).thenReturn(Set.of("org1-id"));
+    when(osp.getNaturalTree(ORG2_ID)).thenReturn(Set.of(ORG2_ID));
   }
 
   @AfterEach
@@ -310,7 +319,7 @@ class SessionBuilderTest {
 
       // The role tree must come from a single batched query, not per-role lazy navigation
       verify(session, times(1)).createQuery(anyString(), eq(UserRoles.class));
-      verify(session, times(1)).createQuery(anyString(), eq(OrgWarehouse.class));
+      verify(session, times(1)).createQuery(anyString(), eq(Warehouse.class));
     }
   }
 

--- a/src-test/src/com/etendoerp/metadata/builders/SessionBuilderTest.java
+++ b/src-test/src/com/etendoerp/metadata/builders/SessionBuilderTest.java
@@ -191,7 +191,11 @@ class SessionBuilderTest {
     when(organization.getId()).thenReturn(ORG_ID);
     when(client.getId()).thenReturn(CLIENT_ID);
     when(warehouse.getId()).thenReturn(WAREHOUSE_ID);
+    when(warehouse.getOrganization()).thenReturn(org1);
     when(language.getLanguage()).thenReturn(LANGUAGE_CODE);
+
+    // validateWarehouseForOrg needs the context role's org list
+    when(role.getADRoleOrganizationList()).thenReturn(Arrays.asList(roleOrg1));
 
     // Mock the HQL join-fetch query that replaces user.getADUserRolesList()
     obDalStatic = mockStatic(OBDal.class);

--- a/src-test/src/com/etendoerp/metadata/builders/SessionBuilderTest.java
+++ b/src-test/src/com/etendoerp/metadata/builders/SessionBuilderTest.java
@@ -93,6 +93,7 @@ class SessionBuilderTest {
   private static final String KEY_ACCT_CENTRALLY = "$IsAcctDimCentrally";
   private static final String KEY_BP_APP_L = "$Element_BP_APP_L";
   private static final String KEY_PR_APP_L = "$Element_PR_APP_L";
+  private static final String ORG1_ID = ORG1_ID;
   private static final String ORG2_ID = "org2-id";
 
   @Mock
@@ -241,8 +242,8 @@ class SessionBuilderTest {
     when(roleOrg2.getOrganization()).thenReturn(org2);
 
     // Setup organizations
-    when(org1.getId()).thenReturn("org1-id");
-    when(org1.get(eq(Organization.PROPERTY_NAME), any(), eq("org1-id"))).thenReturn("Organization 1");
+    when(org1.getId()).thenReturn(ORG1_ID);
+    when(org1.get(eq(Organization.PROPERTY_NAME), any(), eq(ORG1_ID))).thenReturn("Organization 1");
     when(org2.getId()).thenReturn(ORG2_ID);
     when(org2.get(eq(Organization.PROPERTY_NAME), any(), eq(ORG2_ID))).thenReturn("Organization 2");
 
@@ -250,7 +251,7 @@ class SessionBuilderTest {
     when(warehouse1.getId()).thenReturn("warehouse1-id");
     when(warehouse1.get(eq(Warehouse.PROPERTY_NAME), any(), eq("warehouse1-id"))).thenReturn("Warehouse 1");
     when(warehouse1.getOrganization()).thenReturn(warehouseOrg1);
-    when(warehouseOrg1.getId()).thenReturn("org1-id");
+    when(warehouseOrg1.getId()).thenReturn(ORG1_ID);
 
     when(warehouse2.getId()).thenReturn("warehouse2-id");
     when(warehouse2.get(eq(Warehouse.PROPERTY_NAME), any(), eq("warehouse2-id"))).thenReturn("Warehouse 2");
@@ -260,7 +261,7 @@ class SessionBuilderTest {
     // Setup OrganizationStructureProvider for natural tree distribution
     when(obContext.getOrganizationStructureProvider(anyString())).thenReturn(osp);
     // Each org's natural tree contains its own id (warehouse matches its own org)
-    when(osp.getNaturalTree("org1-id")).thenReturn(Set.of("org1-id"));
+    when(osp.getNaturalTree(ORG1_ID)).thenReturn(Set.of(ORG1_ID));
     when(osp.getNaturalTree(ORG2_ID)).thenReturn(Set.of(ORG2_ID));
   }
 

--- a/src-test/src/com/etendoerp/metadata/builders/SessionBuilderTest.java
+++ b/src-test/src/com/etendoerp/metadata/builders/SessionBuilderTest.java
@@ -93,7 +93,7 @@ class SessionBuilderTest {
   private static final String KEY_ACCT_CENTRALLY = "$IsAcctDimCentrally";
   private static final String KEY_BP_APP_L = "$Element_BP_APP_L";
   private static final String KEY_PR_APP_L = "$Element_PR_APP_L";
-  private static final String ORG1_ID = ORG1_ID;
+  private static final String ORG1_ID = "org1-id";
   private static final String ORG2_ID = "org2-id";
 
   @Mock

--- a/src/com/etendoerp/metadata/builders/SessionBuilder.java
+++ b/src/com/etendoerp/metadata/builders/SessionBuilder.java
@@ -96,6 +96,8 @@ public class SessionBuilder extends Builder {
             Organization organization = context.getCurrentOrganization();
             Client client = context.getCurrentClient();
             Warehouse warehouse = context.getWarehouse();
+            // ponytail: if warehouse doesn't belong to the resolved org, pick one that does
+            warehouse = validateWarehouseForOrg(warehouse, organization, role);
 
             json.put("user", getJsonObject(user));
             json.put("currentRole", getJsonObject(role));
@@ -264,5 +266,28 @@ public class SessionBuilder extends Builder {
         }
 
         return warehouses;
+    }
+
+    /**
+     * Returns the given warehouse if it belongs to an organization accessible by the role.
+     * Otherwise returns the first valid warehouse for the current organization.
+     * ponytail: guard against cross-org warehouse from stale token, pick org-scoped fallback
+     */
+    private Warehouse validateWarehouseForOrg(Warehouse warehouse, Organization organization, Role role) {
+        if (warehouse == null) {
+            return null;
+        }
+        String whOrgId = warehouse.getOrganization().getId();
+        boolean belongsToRole = role.getADRoleOrganizationList().stream()
+            .anyMatch(ro -> ro.getOrganization().getId().equals(whOrgId));
+        if (belongsToRole) {
+            return warehouse;
+        }
+        // Fallback: first warehouse linked to the current organization
+        List<OrgWarehouse> orgWarehouses = organization.getOrganizationWarehouseList();
+        if (!orgWarehouses.isEmpty()) {
+            return orgWarehouses.get(0).getWarehouse();
+        }
+        return warehouse;
     }
 }

--- a/src/com/etendoerp/metadata/builders/SessionBuilder.java
+++ b/src/com/etendoerp/metadata/builders/SessionBuilder.java
@@ -164,19 +164,7 @@ public class SessionBuilder extends Builder {
      */
     private Map<String, List<Warehouse>> getWarehousesByOrganization(List<UserRoles> userRoleList) {
         Set<String> orgIds = new LinkedHashSet<>();
-        String clientId = null;
-        for (UserRoles userRole : userRoleList) {
-            try {
-                if (clientId == null) {
-                    clientId = userRole.getRole().getClient().getId();
-                }
-                for (RoleOrganization roleOrg : userRole.getRole().getADRoleOrganizationList()) {
-                    orgIds.add(roleOrg.getOrganization().getId());
-                }
-            } catch (Exception e) {
-                logger.error(e.getMessage(), e);
-            }
-        }
+        String clientId = collectOrgIdsAndClient(userRoleList, orgIds);
 
         if (orgIds.isEmpty() || clientId == null) {
             return Collections.emptyMap();
@@ -192,27 +180,49 @@ public class SessionBuilder extends Builder {
             OrganizationStructureProvider osp = OBContext.getOBContext()
                 .getOrganizationStructureProvider(clientId);
 
-            // ponytail: replicate Classic's natural-tree distribution
-            Map<String, List<Warehouse>> warehousesByOrganization = new HashMap<>();
-            for (String orgId : orgIds) {
-                warehousesByOrganization.put(orgId, new ArrayList<>());
-            }
-            for (Warehouse wh : warehouses) {
-                String whOrgId = wh.getOrganization().getId();
-                for (String orgId : orgIds) {
-                    Set<String> naturalTree = osp.getNaturalTree(orgId);
-                    if (naturalTree.contains(whOrgId)) {
-                        warehousesByOrganization.get(orgId).add(wh);
-                    }
-                }
-            }
-
-            return warehousesByOrganization;
+            return distributeByNaturalTree(warehouses, orgIds, osp);
         } catch (Exception e) {
             logger.error(e.getMessage(), e);
-
             return Collections.emptyMap();
         }
+    }
+
+    private String collectOrgIdsAndClient(List<UserRoles> userRoleList, Set<String> orgIds) {
+        String clientId = null;
+        for (UserRoles userRole : userRoleList) {
+            try {
+                if (clientId == null) {
+                    clientId = userRole.getRole().getClient().getId();
+                }
+                for (RoleOrganization roleOrg : userRole.getRole().getADRoleOrganizationList()) {
+                    orgIds.add(roleOrg.getOrganization().getId());
+                }
+            } catch (Exception e) {
+                logger.error(e.getMessage(), e);
+            }
+        }
+        return clientId;
+    }
+
+    /**
+     * Distributes warehouses across organizations using the natural tree,
+     * replicating Classic's RoleInfo behavior.
+     */
+    private Map<String, List<Warehouse>> distributeByNaturalTree(
+            List<Warehouse> warehouses, Set<String> orgIds, OrganizationStructureProvider osp) {
+        Map<String, List<Warehouse>> result = new HashMap<>();
+        for (String orgId : orgIds) {
+            result.put(orgId, new ArrayList<>());
+        }
+        for (Warehouse wh : warehouses) {
+            String whOrgId = wh.getOrganization().getId();
+            for (String orgId : orgIds) {
+                if (osp.getNaturalTree(orgId).contains(whOrgId)) {
+                    result.get(orgId).add(wh);
+                }
+            }
+        }
+        return result;
     }
 
     private JSONArray getOrganizations(Role role, Map<String, List<Warehouse>> warehousesByOrganization) {

--- a/src/com/etendoerp/metadata/builders/SessionBuilder.java
+++ b/src/com/etendoerp/metadata/builders/SessionBuilder.java
@@ -32,6 +32,7 @@ import org.codehaus.jettison.json.JSONArray;
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
 import org.openbravo.dal.core.OBContext;
+import org.openbravo.dal.security.OrganizationStructureProvider;
 import org.openbravo.dal.service.OBDal;
 import org.openbravo.erpCommon.utility.DimensionDisplayUtility;
 import org.openbravo.model.ad.access.Role;
@@ -68,14 +69,15 @@ public class SessionBuilder extends Builder {
             + " order by ro.name, org.name";
 
     /**
-     * Loads the warehouses for every organization referenced by the user's roles in a single
-     * round trip, replacing the per-organization {@code organization.getOrganizationWarehouseList()}
-     * lazy navigation.
+     * Loads active warehouses whose organization belongs to the role's org set,
+     * matching Classic's RoleInfo.getOrganizationWarehouses() query.
      */
     private static final String WAREHOUSES_BY_ORGANIZATION_HQL =
-        "select distinct ow from OrganizationWarehouse ow"
-            + " join fetch ow.warehouse w"
-            + " where ow.organization.id in (:orgIds)"
+        "select w from Warehouse w"
+            + " where w.active = true"
+            + " and w.organization.id in (:orgIds)"
+            + " and w.client.id = :clientId"
+            + " and w.organization.active = true"
             + " order by w.name";
 
     /**
@@ -131,7 +133,7 @@ public class SessionBuilder extends Builder {
                 .setParameter("userId", cacheKey)
                 .list();
 
-            Map<String, List<OrgWarehouse>> warehousesByOrganization = getWarehousesByOrganization(userRoleList);
+            Map<String, List<Warehouse>> warehousesByOrganization = getWarehousesByOrganization(userRoleList);
 
             for (UserRoles userRole : userRoleList) {
                 JSONObject json = new JSONObject();
@@ -155,13 +157,19 @@ public class SessionBuilder extends Builder {
     }
 
     /**
-     * Batches the warehouse lookup for every organization referenced by the given roles into a
-     * single query, keyed by organization id, instead of lazily loading warehouses per organization.
+     * Distributes warehouses across organizations using the natural tree,
+     * matching Classic's RoleInfo.getOrganizationWarehouses() behavior:
+     * a warehouse appears under every org whose natural tree contains
+     * the warehouse's own organization.
      */
-    private Map<String, List<OrgWarehouse>> getWarehousesByOrganization(List<UserRoles> userRoleList) {
+    private Map<String, List<Warehouse>> getWarehousesByOrganization(List<UserRoles> userRoleList) {
         Set<String> orgIds = new LinkedHashSet<>();
+        String clientId = null;
         for (UserRoles userRole : userRoleList) {
             try {
+                if (clientId == null) {
+                    clientId = userRole.getRole().getClient().getId();
+                }
                 for (RoleOrganization roleOrg : userRole.getRole().getADRoleOrganizationList()) {
                     orgIds.add(roleOrg.getOrganization().getId());
                 }
@@ -170,21 +178,33 @@ public class SessionBuilder extends Builder {
             }
         }
 
-        if (orgIds.isEmpty()) {
+        if (orgIds.isEmpty() || clientId == null) {
             return Collections.emptyMap();
         }
 
         try {
-            List<OrgWarehouse> orgWarehouses = OBDal.getInstance().getSession()
-                .createQuery(WAREHOUSES_BY_ORGANIZATION_HQL, OrgWarehouse.class)
+            List<Warehouse> warehouses = OBDal.getInstance().getSession()
+                .createQuery(WAREHOUSES_BY_ORGANIZATION_HQL, Warehouse.class)
                 .setParameter("orgIds", orgIds)
+                .setParameter("clientId", clientId)
                 .list();
 
-            Map<String, List<OrgWarehouse>> warehousesByOrganization = new HashMap<>();
-            for (OrgWarehouse orgWarehouse : orgWarehouses) {
-                warehousesByOrganization
-                    .computeIfAbsent(orgWarehouse.getOrganization().getId(), id -> new ArrayList<>())
-                    .add(orgWarehouse);
+            OrganizationStructureProvider osp = OBContext.getOBContext()
+                .getOrganizationStructureProvider(clientId);
+
+            // ponytail: replicate Classic's natural-tree distribution
+            Map<String, List<Warehouse>> warehousesByOrganization = new HashMap<>();
+            for (String orgId : orgIds) {
+                warehousesByOrganization.put(orgId, new ArrayList<>());
+            }
+            for (Warehouse wh : warehouses) {
+                String whOrgId = wh.getOrganization().getId();
+                for (String orgId : orgIds) {
+                    Set<String> naturalTree = osp.getNaturalTree(orgId);
+                    if (naturalTree.contains(whOrgId)) {
+                        warehousesByOrganization.get(orgId).add(wh);
+                    }
+                }
             }
 
             return warehousesByOrganization;
@@ -195,7 +215,7 @@ public class SessionBuilder extends Builder {
         }
     }
 
-    private JSONArray getOrganizations(Role role, Map<String, List<OrgWarehouse>> warehousesByOrganization) {
+    private JSONArray getOrganizations(Role role, Map<String, List<Warehouse>> warehousesByOrganization) {
         JSONArray organizations = new JSONArray();
 
         try {
@@ -245,16 +265,15 @@ public class SessionBuilder extends Builder {
         return attributes;
     }
 
-    private JSONArray getWarehouses(Organization organization, Map<String, List<OrgWarehouse>> warehousesByOrganization) {
+    private JSONArray getWarehouses(Organization organization, Map<String, List<Warehouse>> warehousesByOrganization) {
         JSONArray warehouses = new JSONArray();
 
         try {
-            List<OrgWarehouse> orgWarehouses = warehousesByOrganization.getOrDefault(organization.getId(),
+            List<Warehouse> orgWarehouses = warehousesByOrganization.getOrDefault(organization.getId(),
                 Collections.emptyList());
 
-            for (OrgWarehouse orgWarehouse : orgWarehouses) {
+            for (Warehouse warehouse : orgWarehouses) {
                 JSONObject json = new JSONObject();
-                Warehouse warehouse = orgWarehouse.getWarehouse();
 
                 json.put("id", warehouse.getId());
                 json.put("name", warehouse.get(Warehouse.PROPERTY_NAME, language, warehouse.getId()));


### PR DESCRIPTION
## Summary
- When switching roles, `meta/session` could return a `currentWarehouse` belonging to a different organization than `currentOrganization` (e.g. Spanish org + US warehouse)
- Root cause: `SecureLoginServlet` carries the old token's warehouse into the new token without validating it against the resolved org
- Fix: `SessionBuilder.toJSON()` now validates the warehouse belongs to an org accessible by the current role before returning it; falls back to the first warehouse of the current organization if not

## Test plan
- [ ] Set a US role/org/warehouse as default, save, then switch to a Spanish role — verify `meta/session` returns a Spanish warehouse
- [ ] Set a Spanish role as default, log out/in, switch to US role — verify warehouse matches the US org
- [ ] Verify save-as-default works correctly after the fix
- [ ] Verify no regression when role/org/warehouse are all congruent