### PR TITLE
Hotfix ETP-4613: Migrate the classic JS of the remaining Manual Process Definitions

### DIFF
--- a/src-test/src/com/etendoerp/metadata/SSOProviderListActionHandlerTest.java
+++ b/src-test/src/com/etendoerp/metadata/SSOProviderListActionHandlerTest.java
@@ -1,0 +1,259 @@
+/*
+ *************************************************************************
+ * The contents of this file are subject to the Etendo License
+ * (the "License"), you may not use this file except in compliance with
+ * the License.
+ * You may obtain a copy of the License at
+ * https://github.com/etendosoftware/etendo_core/blob/main/legal/Etendo_license.txt
+ * Software distributed under the License is distributed on an
+ * "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing rights
+ * and limitations under the License.
+ * All portions are Copyright © 2021–2026 FUTIT SERVICES, S.L
+ * All Rights Reserved.
+ * Contributor(s): Futit Services S.L.
+ *************************************************************************
+ */
+
+package com.etendoerp.metadata;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.function.Consumer;
+
+import org.codehaus.jettison.json.JSONException;
+import org.codehaus.jettison.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.openbravo.dal.service.OBDal;
+
+import com.etendoerp.etendorx.data.ETRXoAuthProvider;
+
+/**
+ * Tests for {@link SSOProviderListActionHandler}.
+ * <p>
+ * The outbound HTTP call is replaced by overriding
+ * {@link SSOProviderListActionHandler#fetchAvailableProviders(String)}, so every path is exercised
+ * without network access.
+ */
+@ExtendWith(MockitoExtension.class)
+class SSOProviderListActionHandlerTest {
+
+    private static final String STATUS_KEY = "status";
+    private static final String MESSAGE_KEY = "message";
+    private static final String ERROR_CODE_KEY = "errorCode";
+    private static final String SUCCESS_STATUS = "Success";
+    private static final String ERROR_STATUS = "Error";
+    private static final String PARAMS_KEY = "_params";
+    private static final String PROVIDER_ID_KEY = "etrxOauthProviderId";
+    private static final String PROVIDER_ID = "0DF0EFEF0F1F4DEEA25F4DEC5B30969D";
+    private static final String ENDPOINT = "https://sso.example.test/oauth-integrations";
+    private static final String REDIRECT_URI = "http://localhost:8080/etendo/saveTokenMiddleware";
+    private static final String PROVIDERS_KEY = "providers";
+    private static final String START_ENDPOINT_KEY = "startEndpoint";
+    private static final String ACCOUNT_ID = "c45c4946-714a-4e2d-8e30-5944fe2e3533";
+
+    /** A trimmed-down copy of what the middleware actually publishes. */
+    private static final String MIDDLEWARE_PAYLOAD = "{\"google\":{\"name\":\"google\",\"scopes\":["
+            + "{\"name\":\"Google Drive - Edit Access Level\","
+            + "\"scope\":\"https://www.googleapis.com/auth/drive.file\","
+            + "\"description\":\"Allows you to upload and manage files.\"}]}}";
+
+    /**
+     * Handler whose outbound call is stubbed: it either returns a canned body or raises the given
+     * failure, so the parsing and error branches can be reached directly.
+     */
+    private static class StubHandler extends SSOProviderListActionHandler {
+        private final String body;
+        private final IOException failure;
+        private String requestedUrl;
+
+        StubHandler(String body, IOException failure) {
+            this.body = body;
+            this.failure = failure;
+        }
+
+        @Override
+        String fetchAvailableProviders(String url) throws IOException {
+            this.requestedUrl = url;
+            if (failure != null) {
+                throw failure;
+            }
+            return body;
+        }
+
+        /** Avoids the static AD singletons; the identifier itself is not under test here. */
+        @Override
+        String getAccountId() {
+            return ACCOUNT_ID;
+        }
+    }
+
+    /** Publishes no record, for the paths that must fail before one is ever read. */
+    private static final Consumer<OBDal> NO_PROVIDER = obDal -> {
+        // Intentionally empty: an unstubbed OBDal.get answers null, which is the state under test.
+    };
+
+    private JSONObject content(String providerId) throws JSONException {
+        JSONObject params = new JSONObject();
+        params.put(PROVIDER_ID_KEY, providerId);
+        JSONObject root = new JSONObject();
+        root.put(PARAMS_KEY, params);
+        return root;
+    }
+
+    private ETRXoAuthProvider mockProvider(OBDal obDal, String authorizationEndpoint) {
+        ETRXoAuthProvider provider = mock(ETRXoAuthProvider.class);
+        when(provider.getAuthorizationEndpoint()).thenReturn(authorizationEndpoint);
+        when(obDal.get(ETRXoAuthProvider.class, PROVIDER_ID)).thenReturn(provider);
+        return provider;
+    }
+
+    /**
+     * Publishes a record whose redirect URI is readable too. Only the success path reaches that
+     * getter, so the error paths deliberately use {@link #mockProvider} instead: stubbing it there
+     * would be an unnecessary stubbing and strict stubs would fail the test.
+     */
+    private void mockCompleteProvider(OBDal obDal, String authorizationEndpoint) {
+        when(mockProvider(obDal, authorizationEndpoint).getRedirectURI()).thenReturn(REDIRECT_URI);
+    }
+
+    /**
+     * Runs the handler with the DAL singleton stubbed, publishing whatever record the case needs.
+     *
+     * @param handler    the handler under test
+     * @param providerId the identifier travelling in the request
+     * @param dalSetup   populates the stubbed DAL before the call
+     * @return the handler response
+     * @throws JSONException if the request payload cannot be built
+     */
+    private JSONObject run(StubHandler handler, String providerId, Consumer<OBDal> dalSetup)
+            throws JSONException {
+        try (MockedStatic<OBDal> dalMock = mockStatic(OBDal.class)) {
+            OBDal obDal = mock(OBDal.class);
+            dalMock.when(OBDal::getInstance).thenReturn(obDal);
+            dalSetup.accept(obDal);
+            return handler.execute(Collections.emptyMap(), content(providerId).toString());
+        }
+    }
+
+    /**
+     * A well-formed request returns the catalogue verbatim plus the derived start endpoint.
+     *
+     * @throws JSONException if the payloads cannot be built or read
+     */
+    @Test
+    void returnsProvidersAndDerivedStartEndpoint() throws JSONException {
+        StubHandler handler = new StubHandler(MIDDLEWARE_PAYLOAD, null);
+
+        JSONObject result = run(handler, PROVIDER_ID, obDal -> mockCompleteProvider(obDal, ENDPOINT));
+
+        assertEquals(SUCCESS_STATUS, result.getString(STATUS_KEY));
+        assertEquals(ENDPOINT + SSOProviderListActionHandler.START_PATH,
+                result.getString(START_ENDPOINT_KEY));
+        assertEquals(REDIRECT_URI, result.getString("redirectUri"));
+        assertEquals(ACCOUNT_ID, result.getString("accountId"));
+        assertTrue(result.getJSONObject(PROVIDERS_KEY).has("google"));
+        assertEquals(ENDPOINT + SSOProviderListActionHandler.AVAILABLE_PROVIDERS_PATH,
+                handler.requestedUrl);
+    }
+
+    /**
+     * A trailing slash on the stored endpoint must not produce a doubled separator.
+     *
+     * @throws JSONException if the payloads cannot be built or read
+     */
+    @Test
+    void normalizesTrailingSlashInEndpoint() throws JSONException {
+        StubHandler handler = new StubHandler(MIDDLEWARE_PAYLOAD, null);
+
+        run(handler, PROVIDER_ID, obDal -> mockCompleteProvider(obDal, ENDPOINT + "/"));
+
+        assertEquals(ENDPOINT + SSOProviderListActionHandler.AVAILABLE_PROVIDERS_PATH,
+                handler.requestedUrl);
+    }
+
+    /**
+     * A missing provider id is reported as a business error, not raised.
+     *
+     * @throws JSONException if the payloads cannot be built or read
+     */
+    @Test
+    void reportsErrorWhenProviderIdMissing() throws JSONException {
+        JSONObject result = run(new StubHandler(MIDDLEWARE_PAYLOAD, null), "", NO_PROVIDER);
+
+        assertEquals(ERROR_STATUS, result.getString(STATUS_KEY));
+        assertEquals(SSOProviderListActionHandler.ERROR_NO_PROVIDER_ID, result.getString(ERROR_CODE_KEY));
+        assertFalse(result.getString(MESSAGE_KEY).isEmpty());
+    }
+
+    /**
+     * An id that matches no record is reported rather than throwing a null pointer downstream.
+     *
+     * @throws JSONException if the payloads cannot be built or read
+     */
+    @Test
+    void reportsErrorWhenProviderNotFound() throws JSONException {
+        JSONObject result = run(new StubHandler(MIDDLEWARE_PAYLOAD, null), PROVIDER_ID, NO_PROVIDER);
+
+        assertEquals(ERROR_STATUS, result.getString(STATUS_KEY));
+        assertEquals(SSOProviderListActionHandler.ERROR_PROVIDER_NOT_FOUND, result.getString(ERROR_CODE_KEY));
+    }
+
+    /**
+     * Authorization_Endpoint is an optional column, so a blank one is normal data and must produce a
+     * readable message instead of a malformed URL.
+     *
+     * @throws JSONException if the payloads cannot be built or read
+     */
+    @Test
+    void reportsErrorWhenEndpointBlank() throws JSONException {
+        StubHandler handler = new StubHandler(MIDDLEWARE_PAYLOAD, null);
+
+        JSONObject result = run(handler, PROVIDER_ID, obDal -> mockProvider(obDal, "  "));
+
+        assertEquals(ERROR_STATUS, result.getString(STATUS_KEY));
+        // The code is what the caller translates; the English message is only a diagnostic.
+        assertEquals(SSOProviderListActionHandler.ERROR_NO_ENDPOINT, result.getString(ERROR_CODE_KEY));
+    }
+
+    /**
+     * A non-200 answer from the middleware surfaces as an error the caller can display.
+     *
+     * @throws JSONException if the payloads cannot be built or read
+     */
+    @Test
+    void reportsErrorWhenMiddlewareFails() throws JSONException {
+        StubHandler handler = new StubHandler(null, new IOException("The middleware answered HTTP 503"));
+
+        JSONObject result = run(handler, PROVIDER_ID, obDal -> mockProvider(obDal, ENDPOINT));
+
+        assertEquals(ERROR_STATUS, result.getString(STATUS_KEY));
+        assertEquals(SSOProviderListActionHandler.ERROR_UNREACHABLE, result.getString(ERROR_CODE_KEY));
+        assertTrue(result.getString(MESSAGE_KEY).contains("503"));
+    }
+
+    /**
+     * A body that is not JSON must not escape as a raw parser exception.
+     *
+     * @throws JSONException if the payloads cannot be built or read
+     */
+    @Test
+    void reportsErrorWhenPayloadUnreadable() throws JSONException {
+        StubHandler handler = new StubHandler("<html>gateway error</html>", null);
+
+        JSONObject result = run(handler, PROVIDER_ID, obDal -> mockProvider(obDal, ENDPOINT));
+
+        assertEquals(ERROR_STATUS, result.getString(STATUS_KEY));
+        assertEquals(SSOProviderListActionHandler.ERROR_UNREADABLE_RESPONSE, result.getString(ERROR_CODE_KEY));
+    }
+}

--- a/src-test/src/com/etendoerp/metadata/SSOProviderListActionHandlerTest.java
+++ b/src-test/src/com/etendoerp/metadata/SSOProviderListActionHandlerTest.java
@@ -19,14 +19,22 @@ package com.etendoerp.metadata;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.io.OutputStream;
+import java.net.HttpURLConnection;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.function.Consumer;
+
+import javax.servlet.ServletException;
 
 import org.codehaus.jettison.json.JSONException;
 import org.codehaus.jettison.json.JSONObject;
@@ -34,16 +42,21 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.MockedStatic;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.openbravo.dal.core.OBContext;
 import org.openbravo.dal.service.OBDal;
+import org.openbravo.erpCommon.utility.SystemInfo;
 
 import com.etendoerp.etendorx.data.ETRXoAuthProvider;
+import com.sun.net.httpserver.HttpServer;
 
 /**
  * Tests for {@link SSOProviderListActionHandler}.
  * <p>
- * The outbound HTTP call is replaced by overriding
- * {@link SSOProviderListActionHandler#fetchAvailableProviders(String)}, so every path is exercised
- * without network access.
+ * The request paths replace the outbound call by overriding
+ * {@link SSOProviderListActionHandler#fetchAvailableProviders(String)}, so every branch of
+ * {@code execute} is exercised without network access. That method has its own two tests, which
+ * answer it from a throw-away HTTP server bound to the loopback address — it is the only way to
+ * cover the connection handling, and it still contacts nothing outside the machine.
  */
 @ExtendWith(MockitoExtension.class)
 class SSOProviderListActionHandlerTest {
@@ -255,5 +268,113 @@ class SSOProviderListActionHandlerTest {
 
         assertEquals(ERROR_STATUS, result.getString(STATUS_KEY));
         assertEquals(SSOProviderListActionHandler.ERROR_UNREADABLE_RESPONSE, result.getString(ERROR_CODE_KEY));
+    }
+
+    /**
+     * The account id is the instance's System Identifier, read under admin mode and trimmed. The
+     * mode must be restored, since leaking it would let the rest of the request bypass access
+     * control.
+     */
+    @Test
+    void readsTheSystemIdentifierAsAccountId() {
+        try (MockedStatic<OBContext> contextMock = mockStatic(OBContext.class);
+                MockedStatic<SystemInfo> systemInfoMock = mockStatic(SystemInfo.class)) {
+            systemInfoMock.when(SystemInfo::getSystemIdentifier).thenReturn("  " + ACCOUNT_ID + "  ");
+
+            assertEquals(ACCOUNT_ID, new SSOProviderListActionHandler().getAccountId());
+
+            contextMock.verify(() -> OBContext.setAdminMode(true));
+            contextMock.verify(OBContext::restorePreviousMode);
+        }
+    }
+
+    /**
+     * An unreadable identifier downgrades to an empty account id instead of failing the whole call:
+     * the chooser is still worth rendering, and the middleware is the one that judges the account.
+     * The admin mode was entered before the failure, so it must still be restored.
+     */
+    @Test
+    void reportsEmptyAccountIdWhenTheSystemIdentifierCannotBeRead() {
+        try (MockedStatic<OBContext> contextMock = mockStatic(OBContext.class);
+                MockedStatic<SystemInfo> systemInfoMock = mockStatic(SystemInfo.class)) {
+            systemInfoMock.when(SystemInfo::getSystemIdentifier)
+                    .thenThrow(new ServletException("No database connection"));
+
+            assertEquals("", new SSOProviderListActionHandler().getAccountId());
+
+            contextMock.verify(OBContext::restorePreviousMode);
+        }
+    }
+
+    /**
+     * A 200 answer is returned verbatim, so the caller parses exactly what the middleware published.
+     *
+     * @throws IOException if the stub server cannot be started or the read fails
+     */
+    @Test
+    void fetchReturnsTheBodyWhenTheMiddlewareAnswersOk() throws IOException {
+        HttpServer server = startMiddlewareStub(HttpURLConnection.HTTP_OK, MIDDLEWARE_PAYLOAD);
+        try {
+            assertEquals(MIDDLEWARE_PAYLOAD,
+                    new SSOProviderListActionHandler().fetchAvailableProviders(stubUrl(server)));
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    /**
+     * A non-200 answer is raised with its status in the message, which is what {@code execute} turns
+     * into the "unreachable" business error the user finally sees.
+     *
+     * @throws IOException if the stub server cannot be started
+     */
+    @Test
+    void fetchRaisesWhenTheMiddlewareAnswersAnError() throws IOException {
+        HttpServer server = startMiddlewareStub(HttpURLConnection.HTTP_UNAVAILABLE, "service unavailable");
+        try {
+            SSOProviderListActionHandler handler = new SSOProviderListActionHandler();
+            String url = stubUrl(server);
+
+            IOException failure = assertThrows(IOException.class, () -> handler.fetchAvailableProviders(url));
+
+            assertTrue(failure.getMessage().contains(String.valueOf(HttpURLConnection.HTTP_UNAVAILABLE)));
+        } finally {
+            server.stop(0);
+        }
+    }
+
+    /**
+     * Starts a throw-away HTTP server on a free loopback port, answering the available-providers
+     * path with the given status and body. Nothing outside the machine is contacted.
+     *
+     * @param status the HTTP status to answer
+     * @param body   the response body, never empty so the content length is always explicit
+     * @return the started server; the caller stops it
+     * @throws IOException if the server cannot be bound
+     */
+    private HttpServer startMiddlewareStub(int status, String body) throws IOException {
+        HttpServer server = HttpServer.create(new InetSocketAddress(InetAddress.getLoopbackAddress(), 0), 0);
+        server.createContext(SSOProviderListActionHandler.AVAILABLE_PROVIDERS_PATH, exchange -> {
+            byte[] payload = body.getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(status, payload.length);
+            try (OutputStream out = exchange.getResponseBody()) {
+                out.write(payload);
+            }
+            exchange.close();
+        });
+        server.start();
+        return server;
+    }
+
+    /**
+     * Builds the URL the handler would have derived from a provider record pointing at the stub.
+     *
+     * @param server the started stub server
+     * @return the absolute URL of the available-providers path
+     */
+    private String stubUrl(HttpServer server) {
+        InetSocketAddress address = server.getAddress();
+        return "http://" + address.getHostString() + ":" + address.getPort()
+                + SSOProviderListActionHandler.AVAILABLE_PROVIDERS_PATH;
     }
 }

--- a/src-test/src/com/etendoerp/metadata/builders/ReportDefinitionBuilderTest.java
+++ b/src-test/src/com/etendoerp/metadata/builders/ReportDefinitionBuilderTest.java
@@ -1,0 +1,227 @@
+/*
+ *************************************************************************
+ * The contents of this file are subject to the Etendo License
+ * (the "License"), you may not use this file except in compliance with
+ * the License.
+ * You may obtain a copy of the License at
+ * https://github.com/etendosoftware/etendo_core/blob/main/legal/Etendo_license.txt
+ * Software distributed under the License is distributed on an
+ * "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing rights
+ * and limitations under the License.
+ * All portions are Copyright © 2021-2026 FUTIT SERVICES, S.L
+ * All Rights Reserved.
+ * Contributor(s): Futit Services S.L.
+ *************************************************************************
+ */
+package com.etendoerp.metadata.builders;
+
+import static com.etendoerp.metadata.MetadataTestConstants.TEST_ID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import org.codehaus.jettison.json.JSONException;
+import org.codehaus.jettison.json.JSONObject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.MockedConstruction;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+import org.openbravo.client.application.ReportDefinition;
+import org.openbravo.dal.core.OBContext;
+import org.openbravo.model.ad.system.Language;
+import org.openbravo.service.json.DataToJsonConverter;
+
+/**
+ * Tests for {@link ReportDefinitionBuilder}, which publishes the export flags an OBUIAPP_Report
+ * offers so the new UI can render one button per available format.
+ * <p>
+ * Each flag is true when its own template is filled <em>or</em> when the report reuses the PDF
+ * template for that format, which is the rule the classic ParameterWindowComponent applies.
+ */
+@MockitoSettings(strictness = Strictness.LENIENT)
+@ExtendWith(MockitoExtension.class)
+class ReportDefinitionBuilderTest {
+
+    private static final String ID_KEY = "id";
+    private static final String PDF_EXPORT_KEY = "pdfExport";
+    private static final String XLS_EXPORT_KEY = "xlsExport";
+    private static final String HTML_EXPORT_KEY = "htmlExport";
+    private static final String TEMPLATE_PATH = "@basedesign@/org/openbravo/report.jrxml";
+
+    @Mock
+    private ReportDefinition report;
+
+    @Mock
+    private OBContext obContext;
+
+    @Mock
+    private Language language;
+
+    @BeforeEach
+    void setUp() {
+        when(report.getId()).thenReturn(TEST_ID);
+    }
+
+    /**
+     * Builds the JSON with the AD singletons stubbed: {@link Builder} reads the context language
+     * and creates a converter while being constructed, neither of which this builder uses.
+     *
+     * @return the export flags JSON
+     * @throws JSONException if the JSON cannot be assembled
+     */
+    private JSONObject toJSON() throws JSONException {
+        try (MockedStatic<OBContext> mockedContext = mockStatic(OBContext.class);
+                MockedConstruction<DataToJsonConverter> ignored = mockConstruction(DataToJsonConverter.class)) {
+            mockedContext.when(OBContext::getOBContext).thenReturn(obContext);
+            when(obContext.getLanguage()).thenReturn(language);
+
+            return new ReportDefinitionBuilder(report).toJSON();
+        }
+    }
+
+    /**
+     * A report with no template at all offers no export, and still publishes its id.
+     *
+     * @throws JSONException if the JSON cannot be assembled
+     */
+    @Test
+    void reportWithoutTemplatesOffersNoExport() throws JSONException {
+        JSONObject result = toJSON();
+
+        assertEquals(TEST_ID, result.getString(ID_KEY));
+        assertFalse(result.getBoolean(PDF_EXPORT_KEY));
+        assertFalse(result.getBoolean(XLS_EXPORT_KEY));
+        assertFalse(result.getBoolean(HTML_EXPORT_KEY));
+    }
+
+    /**
+     * An empty template string is not a template: the flags stay false.
+     *
+     * @throws JSONException if the JSON cannot be assembled
+     */
+    @Test
+    void emptyTemplatesOfferNoExport() throws JSONException {
+        when(report.getPDFTemplate()).thenReturn("");
+        when(report.getXLSTemplate()).thenReturn("");
+        when(report.getHTMLTemplate()).thenReturn("");
+
+        JSONObject result = toJSON();
+
+        assertFalse(result.getBoolean(PDF_EXPORT_KEY));
+        assertFalse(result.getBoolean(XLS_EXPORT_KEY));
+        assertFalse(result.getBoolean(HTML_EXPORT_KEY));
+    }
+
+    /**
+     * A PDF template enables the PDF export only; it does not imply the other two.
+     *
+     * @throws JSONException if the JSON cannot be assembled
+     */
+    @Test
+    void pdfTemplateEnablesPdfExportAlone() throws JSONException {
+        when(report.getPDFTemplate()).thenReturn(TEMPLATE_PATH);
+
+        JSONObject result = toJSON();
+
+        assertTrue(result.getBoolean(PDF_EXPORT_KEY));
+        assertFalse(result.getBoolean(XLS_EXPORT_KEY));
+        assertFalse(result.getBoolean(HTML_EXPORT_KEY));
+    }
+
+    /**
+     * An XLS template of its own enables the XLS export.
+     *
+     * @throws JSONException if the JSON cannot be assembled
+     */
+    @Test
+    void xlsTemplateEnablesXlsExport() throws JSONException {
+        when(report.getXLSTemplate()).thenReturn(TEMPLATE_PATH);
+
+        JSONObject result = toJSON();
+
+        assertTrue(result.getBoolean(XLS_EXPORT_KEY));
+    }
+
+    /**
+     * Reusing the PDF template for XLS enables the XLS export even with no XLS template of its own.
+     *
+     * @throws JSONException if the JSON cannot be assembled
+     */
+    @Test
+    void reusingThePdfTemplateEnablesXlsExport() throws JSONException {
+        when(report.getXLSTemplate()).thenReturn(null);
+        when(report.isUsePDFAsXLSTemplate()).thenReturn(Boolean.TRUE);
+
+        JSONObject result = toJSON();
+
+        assertTrue(result.getBoolean(XLS_EXPORT_KEY));
+    }
+
+    /**
+     * An HTML template of its own enables the HTML export.
+     *
+     * @throws JSONException if the JSON cannot be assembled
+     */
+    @Test
+    void htmlTemplateEnablesHtmlExport() throws JSONException {
+        when(report.getHTMLTemplate()).thenReturn(TEMPLATE_PATH);
+
+        JSONObject result = toJSON();
+
+        assertTrue(result.getBoolean(HTML_EXPORT_KEY));
+    }
+
+    /**
+     * Reusing the PDF template for HTML enables the HTML export even with no HTML template.
+     *
+     * @throws JSONException if the JSON cannot be assembled
+     */
+    @Test
+    void reusingThePdfTemplateEnablesHtmlExport() throws JSONException {
+        when(report.getHTMLTemplate()).thenReturn(null);
+        when(report.isUsePDFAsHTMLTemplate()).thenReturn(Boolean.TRUE);
+
+        JSONObject result = toJSON();
+
+        assertTrue(result.getBoolean(HTML_EXPORT_KEY));
+    }
+
+    /**
+     * The reuse flags are nullable Booleans in the model, so an unset one must read as false rather
+     * than raising a null unboxing error.
+     *
+     * @throws JSONException if the JSON cannot be assembled
+     */
+    @Test
+    void unsetReuseFlagsAreTreatedAsFalse() throws JSONException {
+        when(report.isUsePDFAsXLSTemplate()).thenReturn(null);
+        when(report.isUsePDFAsHTMLTemplate()).thenReturn(null);
+
+        JSONObject result = toJSON();
+
+        assertFalse(result.getBoolean(XLS_EXPORT_KEY));
+        assertFalse(result.getBoolean(HTML_EXPORT_KEY));
+    }
+
+    /** The builder takes part in the shared Builder hierarchy the metadata services dispatch on. */
+    @Test
+    void isABuilder() {
+        try (MockedStatic<OBContext> mockedContext = mockStatic(OBContext.class);
+                MockedConstruction<DataToJsonConverter> ignored = mockConstruction(DataToJsonConverter.class)) {
+            mockedContext.when(OBContext::getOBContext).thenReturn(obContext);
+            when(obContext.getLanguage()).thenReturn(language);
+
+            assertInstanceOf(Builder.class, new ReportDefinitionBuilder(report));
+        }
+    }
+}

--- a/src-test/src/com/etendoerp/metadata/builders/TabBuilderTest.java
+++ b/src-test/src/com/etendoerp/metadata/builders/TabBuilderTest.java
@@ -556,6 +556,64 @@ class TabBuilderTest extends TabBuilderTestBase {
     }
 
     /**
+     * Tests that a null answer from ApplicationUtils is normalized to an empty string.
+     * <p>
+     * The classic helper returns null for a tab whose parent link cannot be determined, and
+     * {@code parentProperty} is a key clients read unconditionally: publishing a JSON null there
+     * would make them fall back to guessing a column, which is the bug the key exists to prevent.
+     *
+     * @throws Exception if the mocked builder run fails
+     */
+    @Test
+    void parentPropertyIsEmptyWhenApplicationUtilsAnswersNull() throws Exception {
+        TestContext ctx = setupTestContext();
+        Tab mockParentTab = mock(Tab.class);
+
+        setupBasicMocks(ctx.context, ctx.language, ctx.tab, ctx.table, ctx.kernelUtils, List.of());
+        when(ctx.tab.getTabLevel()).thenReturn(1L);
+        when(ctx.kernelUtils.getParentTab(ctx.tab)).thenReturn(mockParentTab);
+
+        try (MockedStatic<ApplicationUtils> mockedAppUtils = mockStatic(ApplicationUtils.class)) {
+            mockedAppUtils.when(() -> ApplicationUtils.getParentProperty(ctx.tab, mockParentTab))
+                    .thenReturn(null);
+
+            executeTabBuilderTest(ctx.context, ctx.kernelUtils, ctx.tab, new JSONObject(), result -> {
+                try {
+                    assertEquals("", result.getString(PARENT_PROPERTY_KEY));
+                    assertEquals(0, result.getJSONArray(PARENT_COLUMN_KEY).length());
+                } catch (JSONException e) {
+                    fail(JSON_EXCEPTION + ": " + e.getMessage());
+                }
+            });
+        }
+    }
+
+    /**
+     * Tests that a level-zero tab reports an empty parentProperty even when KernelUtils hands back
+     * a parent tab, without consulting ApplicationUtils at all: a header tab has no parent to link
+     * to, so its own tab level is the authority.
+     *
+     * @throws Exception if the mocked builder run fails
+     */
+    @Test
+    void parentPropertyIsEmptyForLevelZeroEvenWithAParentTab() throws Exception {
+        TestContext ctx = setupTestContext();
+        Tab mockParentTab = mock(Tab.class);
+
+        setupBasicMocks(ctx.context, ctx.language, ctx.tab, ctx.table, ctx.kernelUtils, List.of());
+        when(ctx.kernelUtils.getParentTab(ctx.tab)).thenReturn(mockParentTab);
+
+        executeTabBuilderTest(ctx.context, ctx.kernelUtils, ctx.tab, new JSONObject(), result -> {
+            try {
+                assertEquals("", result.getString(PARENT_PROPERTY_KEY));
+                assertEquals(0, result.getJSONArray(PARENT_COLUMN_KEY).length());
+            } catch (JSONException e) {
+                fail(JSON_EXCEPTION + ": " + e.getMessage());
+            }
+        });
+    }
+
+    /**
      * Tests that parentColumns falls back to link to parent columns when no parent
      * property is found.
      */

--- a/src-test/src/com/etendoerp/metadata/builders/TabBuilderTest.java
+++ b/src-test/src/com/etendoerp/metadata/builders/TabBuilderTest.java
@@ -75,6 +75,7 @@ class TabBuilderTest extends TabBuilderTestBase {
     private static final String READ_ONLY_KEY = "readOnly";
     private static final String RO_PATTERN = "RO";
     private static final String PARENT_COLUMN_KEY = "parentColumns";
+    private static final String PARENT_PROPERTY_KEY = "parentProperty";
     private static final String OBUIAPP_CAN_ADD_KEY = "obuiappCanAdd";
     private static final String FIELD1_KEY = "field1";
 
@@ -502,10 +503,55 @@ class TabBuilderTest extends TabBuilderTestBase {
                     JSONArray parentColumns = result.getJSONArray(PARENT_COLUMN_KEY);
                     assertEquals(1, parentColumns.length());
                     assertEquals(parentProperty, parentColumns.getString(0));
+                    assertEquals(parentProperty, result.getString(PARENT_PROPERTY_KEY));
                 } catch (JSONException e) {
                     fail(JSON_EXCEPTION + ": " + e.getMessage());
                 }
             });
+        }
+    }
+
+    /**
+     * Tests that parentProperty is published as an empty string when the tab has no link column
+     * to its parent, and that parentColumns still falls back to the link-to-parent columns.
+     * <p>
+     * This is the Sii Monitor case: the child table carries an unrelated isLinkToParentColumn,
+     * so the empty parentProperty is the only way a client can tell that no criteria must be
+     * built from it.
+     *
+     * @throws Exception if the mocked builder run fails
+     */
+    @Test
+    void parentPropertyIsEmptyWhenNoLinkColumnToParent() throws Exception {
+        TestContext ctx = setupTestContext();
+        Tab mockParentTab = mock(Tab.class);
+        Column unrelatedLinkColumn = mock(Column.class);
+        String unrelatedColumnName = "businessPartner";
+        when(unrelatedLinkColumn.isLinkToParentColumn()).thenReturn(true);
+
+        setupBasicMocks(ctx.context, ctx.language, ctx.tab, ctx.table, ctx.kernelUtils,
+                List.of(unrelatedLinkColumn));
+        when(ctx.table.getADColumnList()).thenReturn(new ArrayList<>(List.of(unrelatedLinkColumn)));
+        when(ctx.tab.getTabLevel()).thenReturn(1L);
+        when(ctx.kernelUtils.getParentTab(ctx.tab)).thenReturn(mockParentTab);
+
+        try (MockedStatic<ApplicationUtils> mockedAppUtils = mockStatic(ApplicationUtils.class)) {
+            mockedAppUtils.when(() -> ApplicationUtils.getParentProperty(ctx.tab, mockParentTab))
+                    .thenReturn("");
+
+            executeTabBuilderTest(ctx.context, ctx.kernelUtils, ctx.tab, new JSONObject(), false, null,
+                mockedProcessor -> mockedProcessor.when(() -> TabProcessor.getEntityColumnName(any()))
+                        .thenReturn(unrelatedColumnName),
+                result -> {
+                    try {
+                        assertEquals("", result.getString(PARENT_PROPERTY_KEY));
+                        JSONArray parentColumns = result.getJSONArray(PARENT_COLUMN_KEY);
+                        assertEquals(1, parentColumns.length());
+                        assertEquals(unrelatedColumnName, parentColumns.getString(0));
+                    } catch (JSONException e) {
+                        fail(JSON_EXCEPTION + ": " + e.getMessage());
+                    }
+                });
         }
     }
 

--- a/src-test/src/com/etendoerp/metadata/service/ProfileRequestUtilsTest.java
+++ b/src-test/src/com/etendoerp/metadata/service/ProfileRequestUtilsTest.java
@@ -1,0 +1,245 @@
+/*
+ *************************************************************************
+ * The contents of this file are subject to the Etendo License
+ * (the "License"), you may not use this file except in compliance with
+ * the License.
+ * You may obtain a copy of the License at
+ * https://github.com/etendosoftware/etendo_core/blob/main/legal/Etendo_license.txt
+ * Software distributed under the License is distributed on an
+ * "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing rights
+ * and limitations under the License.
+ * All portions are Copyright © 2021-2026 FUTIT SERVICES, S.L
+ * All Rights Reserved.
+ * Contributor(s): Futit Services S.L.
+ *************************************************************************
+ */
+package com.etendoerp.metadata.service;
+
+import static com.etendoerp.metadata.MetadataTestConstants.ORG_ID;
+import static com.etendoerp.metadata.MetadataTestConstants.WAREHOUSE_ID;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+import java.util.function.Consumer;
+
+import org.codehaus.jettison.json.JSONException;
+import org.codehaus.jettison.json.JSONObject;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.MockedStatic;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.openbravo.dal.service.OBDal;
+import org.openbravo.model.common.enterprise.Organization;
+import org.openbravo.model.common.enterprise.Warehouse;
+
+import com.etendoerp.metadata.exceptions.UnprocessableContentException;
+
+/**
+ * Tests for {@link ProfileRequestUtils}, the body-reading helper shared by {@link LoginService} and
+ * {@link ChangeProfileService}.
+ * <p>
+ * The DAL is replaced by a static mock, so no record ever has to exist for a lookup to be exercised.
+ */
+@ExtendWith(MockitoExtension.class)
+class ProfileRequestUtilsTest {
+
+    private static final String ORGANIZATION_KEY = "organization";
+    private static final String WAREHOUSE_KEY = "warehouse";
+    private static final String UNKNOWN_ID = "no-such-record";
+
+    /**
+     * Builds a one-entry request body.
+     *
+     * @param key   the property name
+     * @param value the property value
+     * @return the body
+     * @throws JSONException if the body cannot be built
+     */
+    private JSONObject body(String key, Object value) throws JSONException {
+        JSONObject json = new JSONObject();
+        json.put(key, value);
+        return json;
+    }
+
+    /**
+     * Runs the given assertions with {@link OBDal#getInstance()} answering a mock, which is what the
+     * two resolvers reach for.
+     *
+     * @param assertions receives the stubbed DAL
+     */
+    private void withDal(Consumer<OBDal> assertions) {
+        try (MockedStatic<OBDal> dalMock = mockStatic(OBDal.class)) {
+            OBDal obDal = mock(OBDal.class);
+            dalMock.when(OBDal::getInstance).thenReturn(obDal);
+            assertions.accept(obDal);
+        }
+    }
+
+    /**
+     * A key nobody sent is absent, not empty.
+     *
+     * @throws JSONException if the body cannot be built
+     */
+    @Test
+    void getStringOrNullReturnsNullWhenKeyIsAbsent() throws JSONException {
+        assertNull(ProfileRequestUtils.getStringOrNull(body(WAREHOUSE_KEY, WAREHOUSE_ID), ORGANIZATION_KEY));
+    }
+
+    /**
+     * An explicit JSON null means "no value", the same as not sending the key at all.
+     *
+     * @throws JSONException if the body cannot be built
+     */
+    @Test
+    void getStringOrNullReturnsNullWhenValueIsJsonNull() throws JSONException {
+        assertNull(ProfileRequestUtils.getStringOrNull(body(ORGANIZATION_KEY, JSONObject.NULL), ORGANIZATION_KEY));
+    }
+
+    /**
+     * An empty string is a cleared field in the UI, so it must not be taken for an id.
+     *
+     * @throws JSONException if the body cannot be built
+     */
+    @Test
+    void getStringOrNullReturnsNullWhenValueIsEmpty() throws JSONException {
+        assertNull(ProfileRequestUtils.getStringOrNull(body(ORGANIZATION_KEY, ""), ORGANIZATION_KEY));
+    }
+
+    /**
+     * A populated key is returned verbatim.
+     *
+     * @throws JSONException if the body cannot be built
+     */
+    @Test
+    void getStringOrNullReturnsTheValue() throws JSONException {
+        assertEquals(ORG_ID, ProfileRequestUtils.getStringOrNull(body(ORGANIZATION_KEY, ORG_ID), ORGANIZATION_KEY));
+    }
+
+    /**
+     * The defensive catch: a body whose read fails is treated as "no value" rather than propagating.
+     * A plain {@link JSONObject} cannot reach it — Jettison's {@code getString} stringifies whatever
+     * it finds — so the failure is injected through a mocked body.
+     *
+     * @throws JSONException never, declared because the stubbed getter is declared to throw it
+     */
+    @Test
+    void getStringOrNullReturnsNullWhenTheValueCannotBeRead() throws JSONException {
+        JSONObject unreadable = mock(JSONObject.class);
+        when(unreadable.has(ORGANIZATION_KEY)).thenReturn(true);
+        when(unreadable.isNull(ORGANIZATION_KEY)).thenReturn(false);
+        when(unreadable.getString(ORGANIZATION_KEY)).thenThrow(new JSONException("unreadable value"));
+
+        assertNull(ProfileRequestUtils.getStringOrNull(unreadable, ORGANIZATION_KEY));
+    }
+
+    /**
+     * Omitting the organization is legal: the caller keeps the session's current one.
+     *
+     * @throws JSONException if the body cannot be built
+     */
+    @Test
+    void resolveOrganizationReturnsNullWhenKeyIsAbsent() throws JSONException {
+        assertNull(ProfileRequestUtils.resolveOrganization(new JSONObject(), ORGANIZATION_KEY));
+    }
+
+    /**
+     * A known id resolves to its record.
+     *
+     * @throws JSONException if the body cannot be built
+     */
+    @Test
+    void resolveOrganizationReturnsTheRecord() throws JSONException {
+        JSONObject request = body(ORGANIZATION_KEY, ORG_ID);
+        Organization organization = mock(Organization.class);
+
+        withDal(obDal -> {
+            when(obDal.get(Organization.class, ORG_ID)).thenReturn(organization);
+            assertSame(organization, ProfileRequestUtils.resolveOrganization(request, ORGANIZATION_KEY));
+        });
+    }
+
+    /**
+     * An id that resolves to nothing is a 422, not a silent null: minting a token for an
+     * organization that does not exist would hide the mistake until much later.
+     *
+     * @throws JSONException if the body cannot be built
+     */
+    @Test
+    void resolveOrganizationRejectsAnUnknownId() throws JSONException {
+        JSONObject request = body(ORGANIZATION_KEY, UNKNOWN_ID);
+
+        withDal(obDal -> {
+            when(obDal.get(Organization.class, UNKNOWN_ID)).thenReturn(null);
+            UnprocessableContentException exception = assertThrows(UnprocessableContentException.class,
+                    () -> ProfileRequestUtils.resolveOrganization(request, ORGANIZATION_KEY));
+            assertTrue(exception.getMessage().contains(UNKNOWN_ID));
+        });
+    }
+
+    /**
+     * Omitting the warehouse is legal, exactly as for the organization.
+     *
+     * @throws JSONException if the body cannot be built
+     */
+    @Test
+    void resolveWarehouseReturnsNullWhenKeyIsAbsent() throws JSONException {
+        assertNull(ProfileRequestUtils.resolveWarehouse(new JSONObject(), WAREHOUSE_KEY));
+    }
+
+    /**
+     * A known id resolves to its record.
+     *
+     * @throws JSONException if the body cannot be built
+     */
+    @Test
+    void resolveWarehouseReturnsTheRecord() throws JSONException {
+        JSONObject request = body(WAREHOUSE_KEY, WAREHOUSE_ID);
+        Warehouse warehouse = mock(Warehouse.class);
+
+        withDal(obDal -> {
+            when(obDal.get(Warehouse.class, WAREHOUSE_ID)).thenReturn(warehouse);
+            assertSame(warehouse, ProfileRequestUtils.resolveWarehouse(request, WAREHOUSE_KEY));
+        });
+    }
+
+    /**
+     * An unknown warehouse id is reported the same way an unknown organization is.
+     *
+     * @throws JSONException if the body cannot be built
+     */
+    @Test
+    void resolveWarehouseRejectsAnUnknownId() throws JSONException {
+        JSONObject request = body(WAREHOUSE_KEY, UNKNOWN_ID);
+
+        withDal(obDal -> {
+            when(obDal.get(Warehouse.class, UNKNOWN_ID)).thenReturn(null);
+            UnprocessableContentException exception = assertThrows(UnprocessableContentException.class,
+                    () -> ProfileRequestUtils.resolveWarehouse(request, WAREHOUSE_KEY));
+            assertTrue(exception.getMessage().contains(UNKNOWN_ID));
+        });
+    }
+
+    /**
+     * The class only publishes static helpers, so its constructor stays private.
+     *
+     * @throws Exception if the constructor cannot be reached by reflection
+     */
+    @Test
+    void constructorIsPrivate() throws Exception {
+        Constructor<ProfileRequestUtils> constructor = ProfileRequestUtils.class.getDeclaredConstructor();
+        assertTrue(Modifier.isPrivate(constructor.getModifiers()), "Constructor should be private");
+
+        constructor.setAccessible(true);
+        assertNotNull(constructor.newInstance());
+    }
+}

--- a/src/com/etendoerp/metadata/SSOProviderListActionHandler.java
+++ b/src/com/etendoerp/metadata/SSOProviderListActionHandler.java
@@ -1,0 +1,233 @@
+/*
+ *************************************************************************
+ * The contents of this file are subject to the Etendo License
+ * (the "License"), you may not use this file except in compliance with
+ * the License.
+ * You may obtain a copy of the License at
+ * https://github.com/etendosoftware/etendo_core/blob/main/legal/Etendo_license.txt
+ * Software distributed under the License is distributed on an
+ * "AS IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+ * implied. See the License for the specific language governing rights
+ * and limitations under the License.
+ * All portions are Copyright © 2021-2026 FUTIT SERVICES, S.L
+ * All Rights Reserved.
+ * Contributor(s): Futit Services S.L.
+ *************************************************************************
+ */
+package com.etendoerp.metadata;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.codehaus.jettison.json.JSONException;
+import org.codehaus.jettison.json.JSONObject;
+import org.openbravo.client.kernel.BaseActionHandler;
+import org.openbravo.dal.core.OBContext;
+import org.openbravo.dal.service.OBDal;
+import org.openbravo.erpCommon.utility.SystemInfo;
+
+import com.etendoerp.etendorx.data.ETRXoAuthProvider;
+
+/**
+ * Returns the OAuth provider catalogue published by an Etendo Middleware instance, so the new UI can
+ * render the "Get Middleware Token" chooser.
+ * <p>
+ * The middleware serves {@code /available-providers} without any {@code Access-Control-Allow-Origin}
+ * header, so no browser can read the response: the classic handler's own {@code fetch}
+ * (ETRX_GetMiddlewareToken.js:21) fails for exactly this reason. Proxying the call server-side is
+ * what makes the process usable at all, and it also covers instances whose users have no direct
+ * internet egress.
+ * <p>
+ * The endpoint to contact is resolved <em>from the provider record</em> rather than taken from the
+ * request, so a caller cannot point this handler at an arbitrary host.
+ * <p>
+ * Input ({@code _params}): <code>{ "etrxOauthProviderId": "&lt;id&gt;" }</code>
+ * <p>
+ * Output on success:
+ * <pre>
+ * { "status": "Success",
+ *   "accountId": "&lt;system identifier&gt;",
+ *   "redirectUri": "&lt;provider redirect URI&gt;",
+ *   "startEndpoint": "&lt;authorization endpoint&gt;/start",
+ *   "providers": { "google": { "name": …, "scopes": [ … ] } } }
+ * </pre>
+ * Failures answer {@code { "status": "Error", "message": … }} instead of throwing: the caller renders
+ * the text, mirroring the message bar the classic handler filled from its {@code .catch()}.
+ */
+@ApplicationScoped
+public class SSOProviderListActionHandler extends BaseActionHandler {
+
+  private static final Logger log = LogManager.getLogger();
+
+  private static final String PARAMS = "_params";
+  private static final String STATUS = "status";
+  private static final String MESSAGE = "message";
+  private static final String ERROR_CODE = "errorCode";
+  private static final String STATUS_SUCCESS = "Success";
+  private static final String STATUS_ERROR = "Error";
+  private static final String PROVIDER_ID_PARAM = "etrxOauthProviderId";
+
+  // Stable error codes. The caller maps these to translated text, so the English `message` beside
+  // them is a diagnostic for logs and support, never what the user reads.
+  static final String ERROR_NO_PROVIDER_ID = "noProviderId";
+  static final String ERROR_PROVIDER_NOT_FOUND = "providerNotFound";
+  static final String ERROR_NO_ENDPOINT = "noEndpoint";
+  static final String ERROR_UNREADABLE_RESPONSE = "unreadableResponse";
+  static final String ERROR_UNREACHABLE = "unreachable";
+
+  /** Path appended to the provider's authorization endpoint to list the available providers. */
+  static final String AVAILABLE_PROVIDERS_PATH = "/available-providers";
+  /** Path appended to the provider's authorization endpoint to begin the consent hand-off. */
+  static final String START_PATH = "/start";
+
+  private static final int CONNECT_TIMEOUT_MS = 10000;
+  private static final int READ_TIMEOUT_MS = 15000;
+
+  @Override
+  protected JSONObject execute(Map<String, Object> parameters, String content) {
+    try {
+      JSONObject params = new JSONObject(content).getJSONObject(PARAMS);
+      String providerId = params.optString(PROVIDER_ID_PARAM, "");
+
+      if (StringUtils.isBlank(providerId)) {
+        return error(ERROR_NO_PROVIDER_ID, "No OAuth provider record was supplied");
+      }
+
+      // Read under the caller's context on purpose: a record the user's role cannot see must not be
+      // proxied on their behalf either.
+      ETRXoAuthProvider provider = OBDal.getInstance().get(ETRXoAuthProvider.class, providerId);
+      if (provider == null) {
+        return error(ERROR_PROVIDER_NOT_FOUND, "OAuth provider record not found: " + providerId);
+      }
+
+      String authorizationEndpoint = StringUtils.trimToEmpty(provider.getAuthorizationEndpoint());
+      if (StringUtils.isBlank(authorizationEndpoint)) {
+        // Authorization_Endpoint is not a mandatory column, so an incomplete record is a normal
+        // data state rather than an exceptional one.
+        return error(ERROR_NO_ENDPOINT, "The OAuth provider record has no Authorization Endpoint configured");
+      }
+      authorizationEndpoint = StringUtils.removeEnd(authorizationEndpoint, "/");
+
+      String body = fetchAvailableProviders(authorizationEndpoint + AVAILABLE_PROVIDERS_PATH);
+
+      return buildSuccess(new JSONObject(body), authorizationEndpoint,
+          StringUtils.trimToEmpty(provider.getRedirectURI()));
+
+    } catch (JSONException e) {
+      log.error("Middleware returned a malformed provider list", e);
+      return error(ERROR_UNREADABLE_RESPONSE, "The middleware returned an unreadable provider list");
+    } catch (Exception e) {
+      log.error("Error retrieving the middleware provider list", e);
+      return error(ERROR_UNREACHABLE,
+          StringUtils.defaultIfBlank(e.getMessage(), "Could not reach the middleware"));
+    }
+  }
+
+  /**
+   * Assembles the success payload. Kept separate from {@link #execute} so the JSON shape can be
+   * asserted without a database or a live middleware.
+   *
+   * @param providers             the raw catalogue as published by the middleware
+   * @param authorizationEndpoint the provider's authorization endpoint, without a trailing slash
+   * @param redirectUri           the provider's redirect URI
+   * @return the response object
+   * @throws JSONException if the response cannot be assembled
+   */
+  JSONObject buildSuccess(JSONObject providers, String authorizationEndpoint, String redirectUri)
+      throws JSONException {
+    JSONObject result = new JSONObject();
+    result.put(STATUS, STATUS_SUCCESS);
+    result.put("providers", providers);
+    result.put("redirectUri", redirectUri);
+    // The classic handler ignores the authorizationEndpoint each provider publishes and derives
+    // this one from the record instead (ETRX_GetMiddlewareToken.js:29); keep that behaviour.
+    result.put("startEndpoint", authorizationEndpoint + START_PATH);
+    result.put("accountId", getAccountId());
+    return result;
+  }
+
+  /**
+   * Reads the instance's System Identifier, which the middleware expects as {@code account_id}.
+   * Equivalent to {@code com.etendoerp.etendorx.GetSSOProperties} with {@code properties=account},
+   * folded in here so the caller needs a single round trip and its click handler stays synchronous.
+   * <p>
+   * An unreadable identifier is downgraded to an empty string rather than failing the whole call:
+   * the chooser is still worth rendering, and the middleware is the one that judges the account.
+   * Package-private so tests can supply a value without the static AD singletons.
+   *
+   * @return the system identifier, or an empty string when it cannot be read
+   */
+  String getAccountId() {
+    boolean adminMode = false;
+    try {
+      OBContext.setAdminMode(true);
+      adminMode = true;
+      return StringUtils.trimToEmpty(SystemInfo.getSystemIdentifier());
+    } catch (Exception e) {
+      log.warn("Could not read the system identifier; account id will be empty", e);
+      return "";
+    } finally {
+      if (adminMode) {
+        OBContext.restorePreviousMode();
+      }
+    }
+  }
+
+  /**
+   * Performs the outbound GET against the middleware. Package-private and overridable so tests can
+   * exercise the parsing and error paths without network access.
+   *
+   * @param url the absolute URL to read
+   * @return the response body
+   * @throws IOException if the request fails or the service answers a non-200 status
+   */
+  String fetchAvailableProviders(String url) throws IOException {
+    HttpURLConnection connection = (HttpURLConnection) new URL(url).openConnection();
+    try {
+      connection.setRequestMethod("GET");
+      connection.setRequestProperty("Accept", "application/json");
+      connection.setConnectTimeout(CONNECT_TIMEOUT_MS);
+      connection.setReadTimeout(READ_TIMEOUT_MS);
+
+      int status = connection.getResponseCode();
+      if (status != HttpURLConnection.HTTP_OK) {
+        throw new IOException("The middleware answered HTTP " + status);
+      }
+
+      try (InputStream in = connection.getInputStream()) {
+        return new String(in.readAllBytes(), StandardCharsets.UTF_8);
+      }
+    } finally {
+      connection.disconnect();
+    }
+  }
+
+  /**
+   * Builds a business-error response. Errors are reported in the payload rather than thrown so the
+   * caller can show the reason instead of a generic failure.
+   *
+   * @param errorCode a stable code the caller maps to translated text
+   * @param message   an English diagnostic for logs and support, not for display
+   * @return the error response object
+   */
+  private JSONObject error(String errorCode, String message) {
+    JSONObject result = new JSONObject();
+    try {
+      result.put(STATUS, STATUS_ERROR);
+      result.put(ERROR_CODE, errorCode);
+      result.put(MESSAGE, message);
+    } catch (JSONException e) {
+      throw new IllegalStateException("Failed to build error JSON", e);
+    }
+    return result;
+  }
+}

--- a/src/com/etendoerp/metadata/builders/TabBuilder.java
+++ b/src/com/etendoerp/metadata/builders/TabBuilder.java
@@ -57,10 +57,16 @@ public class TabBuilder extends Builder {
   /** HQL property name every entity's primary key is universally mapped to. */
   private static final String ID_HQL_NAME = "id";
 
+  /** Key under which the authoritative link-to-parent property is published. */
+  private static final String PARENT_PROPERTY = "parentProperty";
+
   private final Tab tab;
   private final TabAccess tabAccess;
   private final boolean isWindowReadOnly;
   private final List<FieldAccess> preloadedFieldAccessList;
+
+  /** Memoized result of {@link #resolveParentProperty()}; {@code null} until first resolved. */
+  private String parentProperty;
 
   /**
    * Constructs a TabBuilder for the given tab.
@@ -128,6 +134,13 @@ public class TabBuilder extends Builder {
 
       if (parentTab != null) {
         json.put("parentTabId", parentTab.getId());
+        // Classic's own answer, empty string included. An empty value is a real answer — "this
+        // tab has no link column to its parent" — and the grid must then filter through the
+        // tab's hqlwhereclause instead of an invented criteria, exactly as OBViewGrid does.
+        // parentColumns cannot carry it: when the property is blank that array falls back to
+        // every isLinkToParentColumn of the table, which is what made clients pick an
+        // unrelated column. See ApplicationUtils.getParentProperty.
+        json.put(PARENT_PROPERTY, resolveParentProperty());
       }
 
       if (Boolean.TRUE.equals(tab.isTreeIncluded())) {
@@ -174,6 +187,26 @@ public class TabBuilder extends Builder {
   }
 
   /**
+   * Resolves this tab's link-to-parent property with the very function the classic UI uses,
+   * {@link ApplicationUtils#getParentProperty(Tab, Tab)}, and memoizes the result so the two
+   * consumers ({@link #getParentColumns()} and the {@code parentProperty} JSON key) never
+   * disagree and never pay for the lookup twice.
+   *
+   * @return the property name, or an empty string when the tab has no link column to its parent
+   *         (a legitimate answer: such tabs are filtered by their hqlwhereclause alone)
+   */
+  private String resolveParentProperty() {
+    if (parentProperty == null) {
+      Tab parentTab = tab.getTabLevel() == 0 ? null : getParentTab();
+      parentProperty = parentTab == null ? "" : ApplicationUtils.getParentProperty(tab, parentTab);
+      if (parentProperty == null) {
+        parentProperty = "";
+      }
+    }
+    return parentProperty;
+  }
+
+  /**
    * Parses the display logic string into a JavaScript expression.
    *
    * @param displayLogic the display logic string to parse
@@ -208,13 +241,13 @@ public class TabBuilder extends Builder {
     }
 
     if (parentTab != null) {
-      String parentProperty = ApplicationUtils.getParentProperty(tab, parentTab);
-      if (StringUtils.isNotBlank(parentProperty)) {
-        jsonColumns.put(parentProperty);
-        if (!linkToParentColumns.isEmpty() && !linkToParentColumns.contains(parentProperty)) {
+      String resolvedParentProperty = resolveParentProperty();
+      if (StringUtils.isNotBlank(resolvedParentProperty)) {
+        jsonColumns.put(resolvedParentProperty);
+        if (!linkToParentColumns.isEmpty() && !linkToParentColumns.contains(resolvedParentProperty)) {
           logger.warn(
               "Parent columns mismatch in tab {} ({}). parentTabId={}, parentProperty='{}', linkToParentColumns={}",
-              tab.getId(), tab.getName(), parentTab.getId(), parentProperty, linkToParentColumns);
+              tab.getId(), tab.getName(), parentTab.getId(), resolvedParentProperty, linkToParentColumns);
         }
         return jsonColumns;
       }


### PR DESCRIPTION
Test Plan

1. Open/Close Periods (“Open/Close” button in Period or Period Control): Previously, this displayed an empty popup. Now, it should open a dialog with a dynamically populated “Action” dropdown (ACTION_COMBO) and Confirm/Cancel buttons. Confirm executes the action and refreshes the grid with a message; Cancel closes the dialog without an error.
2. Any simple manual process (e.g., “Recalculate Role Permissions” or a similar button without parameters): It should execute immediately with a brief loading animation, without an empty dialog or an extra “Execute” click.
3. Process with native confirm()—e.g., SII Invoice Sender (button on the Invoice screen, if you have the SII module enabled): the browser’s confirm dialog must appear with the text in Spanish; Accept runs the handler and displays a message plus refreshes the grid; Cancel closes the modal without an error banner.
4. Get Middleware Token (ETRXGetMiddlewareToken, button in ETRX OAuth Provider): opens the custom component with provider cards and scope icons. Clicking a scope should open a popup to the auth URL. Error cases to validate with incomplete data: provider without an ID → “no record selected” message; provider without a configured Authorization Endpoint → missing endpoint message (not a raw code displayed on screen).
5. Blocked pop-up: In any of the previous processes that open a pop-up (Get Middleware Token or “Get Token”), block pop-ups in the browser before clicking. The “pop-up blocked” banner must appear with a real link that actually opens when clicked.
6. Get Token (ETRX_oAuth_Provider.GET_Token) — the report itself from 

Translated with DeepL.com (free version)